### PR TITLE
feat: add typed release pipeline and responsive layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -35,7 +35,13 @@ jobs:
           python -m pip install -r requirements-dev.txt
 
       - name: Lint i18n and tests
-        run: python -m ruff check i18n.py i18n_audit.py tests
+        run: python -m ruff check editor_config.py editor_ui_smoke.py i18n.py i18n_audit.py editor_layout_audit.py editor_runtime.py release_package.py responsive_tk.py responsive_ui_smoke.py tests
 
-      - name: Run tests
-        run: python -m pytest -q
+      - name: Type check typed core
+        run: python -m mypy
+
+      - name: Run tests with coverage
+        run: python -m coverage run -m pytest -q
+
+      - name: Enforce coverage
+        run: python -m coverage report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,232 @@
+name: Build Windows EXE
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows-exe:
+    name: Windows x86 executable
+    runs-on: windows-latest
+    timeout-minutes: 30
+    outputs:
+      exe_name: ${{ steps.package.outputs.exe_name }}
+      manifest_name: ${{ steps.package.outputs.manifest_name }}
+      sha_name: ${{ steps.package.outputs.sha_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Python 3.8 win32
+        shell: pwsh
+        run: |
+          $pythonInstaller = Join-Path $env:RUNNER_TEMP "python-3.8.10.exe"
+          $pythonDir = Join-Path $env:RUNNER_TEMP "python-3.8.10-win32"
+          Invoke-WebRequest `
+            -Uri "https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe" `
+            -OutFile $pythonInstaller
+          Start-Process `
+            -FilePath $pythonInstaller `
+            -ArgumentList "/quiet InstallAllUsers=0 TargetDir=`"$pythonDir`" Include_pip=1 Include_test=0 PrependPath=0" `
+            -Wait
+
+          $python = Join-Path $pythonDir "python.exe"
+          @'
+          import platform
+          import sys
+
+          if platform.architecture()[0] != "32bit":
+              raise SystemExit(f"Expected 32bit Python, got {platform.architecture()[0]}")
+          if sys.version_info[:2] != (3, 8):
+              raise SystemExit(f"Expected Python 3.8, got {sys.version}")
+          '@ | & $python -
+          "PYTHON_EXE=$python" >> $env:GITHUB_ENV
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          $python = $env:PYTHON_EXE
+          & $python -m pip install --upgrade pip
+          & $python -m pip install -r requirements.txt
+          & $python -m pip install pyinstaller
+
+      - name: Read version
+        id: version
+        shell: pwsh
+        run: |
+          $version = (Get-Content version.txt -Raw).Trim()
+          if (-not $version) {
+            throw "version.txt is empty"
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Build executable
+        shell: pwsh
+        run: |
+          $python = $env:PYTHON_EXE
+          & $python -m PyInstaller `
+            --noconfirm `
+            --clean `
+            --onefile `
+            --windowed `
+            --name "win7_x86.PVZHybrid_Editor_b${{ steps.version.outputs.version }}" `
+            --icon res/icon/editor.ico `
+            --add-data "locales:locales" `
+            --add-data "res:res" `
+            --add-data "version.txt:." `
+            editor.py
+
+      - name: Write checksum and package manifest
+        id: package
+        shell: pwsh
+        run: |
+          $python = $env:PYTHON_EXE
+          & $python release_package.py `
+            --dist-dir dist `
+            --version-file version.txt `
+            --github-output $env:GITHUB_OUTPUT
+
+      - name: Upload executable artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ steps.package.outputs.exe_path }}
+          archive: false
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ steps.package.outputs.sha_path }}
+          archive: false
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload package manifest artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ steps.package.outputs.manifest_path }}
+          archive: false
+          if-no-files-found: error
+          retention-days: 30
+
+  responsive-ui-smoke:
+    name: Windows responsive UI smoke
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install screenshot dependency
+        run: python -m pip install Pillow
+
+      - name: Capture responsive UI screenshot
+        run: python responsive_ui_smoke.py --output-dir ui-smoke-artifacts
+
+      - name: Upload responsive UI screenshot
+        uses: actions/upload-artifact@v7
+        with:
+          path: ui-smoke-artifacts/responsive-ui-smoke.png
+          archive: false
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload responsive UI audit
+        uses: actions/upload-artifact@v7
+        with:
+          path: ui-smoke-artifacts/responsive-ui-smoke.json
+          archive: false
+          if-no-files-found: error
+          retention-days: 30
+
+  actual-editor-ui-smoke:
+    name: Windows actual editor UI smoke
+    runs-on: windows-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install editor dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Capture actual editor UI screenshot
+        run: python editor_ui_smoke.py --output-dir editor-ui-smoke-artifacts
+
+      - name: Upload actual editor UI screenshot
+        uses: actions/upload-artifact@v7
+        with:
+          path: editor-ui-smoke-artifacts/editor-ui-smoke.png
+          archive: false
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload actual editor UI audit
+        uses: actions/upload-artifact@v7
+        with:
+          path: editor-ui-smoke-artifacts/editor-ui-smoke.json
+          archive: false
+          if-no-files-found: error
+          retention-days: 30
+
+  release-assets:
+    name: Publish tag release assets
+    if: github.ref_type == 'tag' && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'b'))
+    needs: build-windows-exe
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download executable artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.build-windows-exe.outputs.exe_name }}
+          path: dist
+          skip-decompress: true
+
+      - name: Download checksum artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.build-windows-exe.outputs.sha_name }}
+          path: dist
+          skip-decompress: true
+
+      - name: Download package manifest artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.build-windows-exe.outputs.manifest_name }}
+          path: dist
+          skip-decompress: true
+
+      - name: Upload release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "${{ github.ref_name }}" \
+            || gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes "Automated Windows executable build."
+          gh release upload "${{ github.ref_name }}" dist/* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build Windows EXE
+name: Build Windows Test EXE
 
 on:
   push:
@@ -9,14 +9,93 @@ permissions:
   contents: read
 
 jobs:
-  build-windows-exe:
-    name: Windows x86 executable
+  build-standard-windows-exe:
+    name: Windows standard executable
     runs-on: windows-latest
     timeout-minutes: 30
-    outputs:
-      exe_name: ${{ steps.package.outputs.exe_name }}
-      manifest_name: ${{ steps.package.outputs.manifest_name }}
-      sha_name: ${{ steps.package.outputs.sha_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          architecture: "x64"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pyinstaller
+
+      - name: Resolve build version from current commit
+        id: build_version
+        shell: pwsh
+        run: |
+          $version = (git rev-parse HEAD).Trim()
+          if (-not $version) {
+            throw "commit version is empty"
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Build executable
+        shell: pwsh
+        run: |
+          python -m PyInstaller `
+            --noconfirm `
+            --clean `
+            --onefile `
+            --windowed `
+            --name "PVZHybrid_Editor_b${{ steps.build_version.outputs.version }}" `
+            --icon res/icon/editor.ico `
+            --add-data "locales:locales" `
+            --add-data "res:res" `
+            --add-data "version.txt:." `
+            editor.py
+
+      - name: Write checksum and package manifest
+        id: package
+        shell: pwsh
+        run: |
+          python release_package.py `
+            --dist-dir dist `
+            --version "${{ steps.build_version.outputs.version }}" `
+            --no-platform-tag `
+            --github-output $env:GITHUB_OUTPUT
+
+      - name: Upload executable artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.package.outputs.exe_name }}
+          path: ${{ steps.package.outputs.exe_path }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.package.outputs.sha_name }}
+          path: ${{ steps.package.outputs.sha_path }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload package manifest artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.package.outputs.manifest_name }}
+          path: ${{ steps.package.outputs.manifest_path }}
+          if-no-files-found: error
+          retention-days: 30
+
+  build-win7-windows-exe:
+    name: Windows win7 x86 executable
+    runs-on: windows-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -55,13 +134,13 @@ jobs:
           & $python -m pip install -r requirements.txt
           & $python -m pip install pyinstaller
 
-      - name: Read version
-        id: version
+      - name: Resolve build version from current commit
+        id: build_version
         shell: pwsh
         run: |
-          $version = (Get-Content version.txt -Raw).Trim()
+          $version = (git rev-parse HEAD).Trim()
           if (-not $version) {
-            throw "version.txt is empty"
+            throw "commit version is empty"
           }
           "version=$version" >> $env:GITHUB_OUTPUT
 
@@ -74,7 +153,7 @@ jobs:
             --clean `
             --onefile `
             --windowed `
-            --name "win7_x86.PVZHybrid_Editor_b${{ steps.version.outputs.version }}" `
+            --name "win7_x86.PVZHybrid_Editor_b${{ steps.build_version.outputs.version }}" `
             --icon res/icon/editor.ico `
             --add-data "locales:locales" `
             --add-data "res:res" `
@@ -88,7 +167,8 @@ jobs:
           $python = $env:PYTHON_EXE
           & $python release_package.py `
             --dist-dir dist `
-            --version-file version.txt `
+            --version "${{ steps.build_version.outputs.version }}" `
+            --platform-tag win7_x86 `
             --github-output $env:GITHUB_OUTPUT
 
       - name: Upload executable artifact
@@ -190,41 +270,3 @@ jobs:
           path: editor-ui-smoke-artifacts/editor-ui-smoke.json
           if-no-files-found: error
           retention-days: 30
-
-  release-assets:
-    name: Publish tag release assets
-    if: github.ref_type == 'tag' && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'b'))
-    needs: build-windows-exe
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download executable artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ needs.build-windows-exe.outputs.exe_name }}
-          path: dist
-
-      - name: Download checksum artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ needs.build-windows-exe.outputs.sha_name }}
-          path: dist
-
-      - name: Download package manifest artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ needs.build-windows-exe.outputs.manifest_name }}
-          path: dist
-
-      - name: Upload release assets
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          gh release view "${{ github.ref_name }}" \
-            || gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes "Automated Windows executable build."
-          gh release upload "${{ github.ref_name }}" dist/* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release view "${{ github.ref_name }}" \
             || gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes "Automated Windows executable build."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,24 +94,24 @@ jobs:
       - name: Upload executable artifact
         uses: actions/upload-artifact@v7
         with:
+          name: ${{ steps.package.outputs.exe_name }}
           path: ${{ steps.package.outputs.exe_path }}
-          archive: false
           if-no-files-found: error
           retention-days: 30
 
       - name: Upload checksum artifact
         uses: actions/upload-artifact@v7
         with:
+          name: ${{ steps.package.outputs.sha_name }}
           path: ${{ steps.package.outputs.sha_path }}
-          archive: false
           if-no-files-found: error
           retention-days: 30
 
       - name: Upload package manifest artifact
         uses: actions/upload-artifact@v7
         with:
+          name: ${{ steps.package.outputs.manifest_name }}
           path: ${{ steps.package.outputs.manifest_path }}
-          archive: false
           if-no-files-found: error
           retention-days: 30
 
@@ -140,16 +140,16 @@ jobs:
       - name: Upload responsive UI screenshot
         uses: actions/upload-artifact@v7
         with:
+          name: responsive-ui-smoke.png
           path: ui-smoke-artifacts/responsive-ui-smoke.png
-          archive: false
           if-no-files-found: error
           retention-days: 30
 
       - name: Upload responsive UI audit
         uses: actions/upload-artifact@v7
         with:
+          name: responsive-ui-smoke.json
           path: ui-smoke-artifacts/responsive-ui-smoke.json
-          archive: false
           if-no-files-found: error
           retention-days: 30
 
@@ -178,16 +178,16 @@ jobs:
       - name: Upload actual editor UI screenshot
         uses: actions/upload-artifact@v7
         with:
+          name: editor-ui-smoke.png
           path: editor-ui-smoke-artifacts/editor-ui-smoke.png
-          archive: false
           if-no-files-found: error
           retention-days: 30
 
       - name: Upload actual editor UI audit
         uses: actions/upload-artifact@v7
         with:
+          name: editor-ui-smoke.json
           path: editor-ui-smoke-artifacts/editor-ui-smoke.json
-          archive: false
           if-no-files-found: error
           retention-days: 30
 
@@ -206,21 +206,18 @@ jobs:
         with:
           name: ${{ needs.build-windows-exe.outputs.exe_name }}
           path: dist
-          skip-decompress: true
 
       - name: Download checksum artifact
         uses: actions/download-artifact@v8
         with:
           name: ${{ needs.build-windows-exe.outputs.sha_name }}
           path: dist
-          skip-decompress: true
 
       - name: Download package manifest artifact
         uses: actions/download-artifact@v8
         with:
           name: ${{ needs.build-windows-exe.outputs.manifest_name }}
           path: dist
-          skip-decompress: true
 
       - name: Upload release assets
         shell: bash

--- a/editor.py
+++ b/editor.py
@@ -1212,8 +1212,11 @@ def mainWindow():
 
     # style=ttk.Style()
     # style.configure('small.TButton',font=("黑体",8),padding=(0,0,0,0))
-    process_frame = ttk.Frame(main_window)
-    process_frame.place(x=0, y=0, relx=1, rely=1, anchor=SE)
+    bottom_bar = ttk.Frame(main_window)
+    bottom_bar.pack(side=BOTTOM, fill=X, padx=3, pady=(0, 3))
+
+    process_frame = ttk.Frame(bottom_bar)
+    process_frame.pack(side=RIGHT, padx=(6, 0))
     process_label = ttk.Label(process_frame, text="", font=("黑体", 8))
     process_label.pack(side=LEFT)
 
@@ -1270,13 +1273,13 @@ def mainWindow():
     choose_process_button.pack(side=LEFT)
     back_ground_status = ttk.IntVar(main_window)
     back_ground_check = ttk.Checkbutton(
-        main_window,
+        bottom_bar,
         text="后台运行",
         variable=back_ground_status,
         bootstyle="round-toggle",
         command=lambda: pvz.backGround(back_ground_status.get()),
     )
-    back_ground_check.place(x=3, y=-3, relx=0, rely=1, anchor=SW)
+    back_ground_check.pack(side=LEFT, padx=(0, 6))
 
     main_viewport = responsive_tk.create_scrollable_viewport(
         main_window,
@@ -1284,7 +1287,7 @@ def mainWindow():
         tk_module=tk,
         min_content_width=900,
         min_content_height=650,
-        bottom_margin=25,
+        bottom_margin=0,
     )
     page_tab = ttk.Notebook(main_viewport.frame)
     page_tab.pack(fill=BOTH, expand=True)
@@ -8840,19 +8843,19 @@ def mainWindow():
 
     # 创建一个按钮，用于加载插件
     plugin_button = ttk.Button(
-        main_window,
+        bottom_bar,
         text="载入插件",
         padding=0,
         bootstyle="primary",
         cursor="hand2",
         command=lambda: load_plugin(main_window),
     )
-    plugin_button.place(x=100, y=0, relx=0, rely=1, anchor="sw")
+    plugin_button.pack(side=LEFT)
 
     # 在“载入插件”和“选择游戏”按钮之间显示醒目的提示
     # 将提示放在窗口底部居中，使用红色粗体以提高可见性
     unsupported_label = ttk.Label(
-        main_window,
+        bottom_bar,
         text="重制版修改器点这里",
         font=(
             "黑体",
@@ -8863,8 +8866,7 @@ def mainWindow():
         bootstyle=("danger",),
         cursor="hand2",  # 鼠标悬停时变成小手图标，提升交互体验
     )
-    # 放置在底部中间，略微向上偏移与其他底部控件错开
-    unsupported_label.place(relx=0.5, rely=1, y=-3, anchor="s")
+    unsupported_label.pack(side=LEFT, expand=True, padx=(8, 8))
 
     # ----------------- 添加点击跳转逻辑 -----------------
 
@@ -8875,8 +8877,8 @@ def mainWindow():
     # 将鼠标左键点击事件绑定到这个 Label 上
     unsupported_label.bind("<Button-1>", open_bilibili_link)
 
-    language_frame = ttk.Frame(main_window)
-    language_frame.place(x=-5, y=-3, relx=1, rely=1, anchor=SE)
+    language_frame = ttk.Frame(bottom_bar)
+    language_frame.pack(side=RIGHT, padx=(8, 0))
     ttk.Label(language_frame, text="语言", font=("黑体", 8)).pack(side=LEFT)
     language_combobox = ttk.Combobox(
         language_frame,

--- a/editor.py
+++ b/editor.py
@@ -22,7 +22,10 @@ import requests
 import keyboard
 import json
 import webbrowser
+import editor_config
+import editor_runtime
 import i18n
+import responsive_tk
 
 # import ctypes
 import sys
@@ -95,100 +98,51 @@ action_list = [
     "游戏减速",
     "随机卡槽",
 ]
-# 默认配置
-default_config = {
-    "language": i18n.DEFAULT_LANGUAGE,
-    "shortcuts": {
-        "key1": {"key": "ctrl+space", "action": 0},
-        "key2": {"key": "Ctrl+f2", "action": 1},
-        "key3": {"key": "Ctrl+f3", "action": 2},
-        "key4": {"key": "Ctrl+f4", "action": 3},
-        "key5": {"key": "Ctrl+f5", "action": 4},
-        "key6": {"key": "Ctrl+f6", "action": 5},
-        "key7": {"key": "Ctrl+f7", "action": 6},
-        "key8": {"key": "Ctrl+f8", "action": 7},
-        "key9": {"key": "Ctrl+f9", "action": 8},
-        "key10": {"key": "Ctrl+f10", "action": 9},
-        "key11": {"key": "Ctrl+f11", "action": 10},
-        "key12": {"key": "Ctrl+f12", "action": 11},
-    }
-}
+default_config = editor_config.default_config()
 # 点击关闭退出
 
 
 def resource_path(relative_path):
     """获取资源的绝对路径，适用于开发环境和PyInstaller环境"""
-    try:
-        # PyInstaller创建的临时文件夹的路径存储在_MEIPASS中
-        base_path = sys._MEIPASS
-    except Exception:
-        base_path = os.path.abspath(".")
-
-    return os.path.join(base_path, relative_path)
+    return editor_runtime.resource_path(relative_path, runtime=sys)
 
 
-# 定义应用程序名称
-app_name = "PVZHybrid_Editor"
-
-# 获取当前用户的AppData目录路径
-appdata_path = os.getenv("APPDATA")
-
-# 在AppData目录下为你的应用创建一个配置文件夹
-app_config_path = os.path.join(appdata_path, app_name)
-if not os.path.exists(app_config_path):
-    os.makedirs(app_config_path)
-
-# 定义配置文件的路径
-config_file_path = os.path.join(app_config_path, "config.json")
+app_name = editor_config.APP_NAME
+app_config_path = str(editor_config.app_config_path(os.getenv("APPDATA")))
+config_file_path = str(editor_config.config_file_path(os.getenv("APPDATA")))
 
 # 创建配置文件的函数
 
 
 def create_config(file_path, default_config):
-    with open(file_path, "w") as file:
-        json.dump(default_config, file, indent=4, ensure_ascii=False)
+    editor_config.create_config(file_path, default_config)
 
 
 # 读取配置文件的函数
 
 
 def load_config(file_path):
-    try:
-        with open(file_path, "r", encoding="utf-8") as file:
-            return json.load(file)
-    except FileNotFoundError:
-        return default_config
-    except:
-        delete_config()
+    return editor_config.load_config(file_path)
 
 
 # 修改配置文件的函数
 
 
 def modify_config(file_path, section, key, value):
-    config = load_config(file_path)
-    if section not in config:
-        config[section] = {}
-    config[section][key] = value
-    save_config(config, file_path)
+    editor_config.modify_config(file_path, section, key, value)
 
 
 # 更新配置文件的函数
 def save_config(config, file_path):
-    with open(file_path, "w") as file:
-        json.dump(config, file, indent=4, ensure_ascii=False)
+    editor_config.save_config(config, file_path)
 
 
 def get_config_language():
-    config = load_config(config_file_path)
-    return i18n.safe_language(config.get("language"))
+    return editor_config.get_config_language(config_file_path)
 
 
 def set_config_language(language):
-    language = i18n.normalize_language(language)
-    config = load_config(config_file_path)
-    config["language"] = language
-    save_config(config, config_file_path)
+    editor_config.set_config_language(config_file_path, language)
 
 
 i18n.set_language(get_config_language())
@@ -234,277 +188,11 @@ def chooseGame():
         try:
             match = re.search(r"{{(.+?)}}", process1)
             window_name = match.group(1) if match else process1
-            if "v2.0" in window_name:
-                PVZ_data.update_PVZ_version(2.0)
+            detected_version = editor_runtime.detect_game_version(window_name)
+            if detected_version is not None:
+                PVZ_data.update_PVZ_version(detected_version)
                 main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.1" in window_name:
-                PVZ_data.update_PVZ_version(2.1)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.2" in window_name:
-                PVZ_data.update_PVZ_version(2.2)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3.5" in window_name:
-                PVZ_data.update_PVZ_version(2.35)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3.6" in window_name:
-                PVZ_data.update_PVZ_version(2.36)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3.7" in window_name:
-                PVZ_data.update_PVZ_version(2.37)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3" in window_name:
-                PVZ_data.update_PVZ_version(2.3)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.4" in window_name:
-                PVZ_data.update_PVZ_version(2.4)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.5" in window_name:
-                PVZ_data.update_PVZ_version(2.5)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.6.1" in window_name:
-                PVZ_data.update_PVZ_version(2.61)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.6" in window_name:
-                PVZ_data.update_PVZ_version(2.6)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.0" in window_name:
-                PVZ_data.update_PVZ_version(3.0)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.17" in window_name:
-                PVZ_data.update_PVZ_version(3.17)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.16" in window_name:
-                PVZ_data.update_PVZ_version(3.16)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.15" in window_name:
-                PVZ_data.update_PVZ_version(3.151)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.14" in window_name:
-                PVZ_data.update_PVZ_version(3.14)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.13.2" in window_name:
-                PVZ_data.update_PVZ_version(3.132)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.12" in window_name:
-                PVZ_data.update_PVZ_version(3.12)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.11" in window_name:
-                PVZ_data.update_PVZ_version(3.11)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.1.5" in window_name:
-                PVZ_data.update_PVZ_version(3.15)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.1" in window_name:
-                PVZ_data.update_PVZ_version(3.1)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.2.1" in window_name:
-                PVZ_data.update_PVZ_version(3.21)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.2" in window_name:
-                PVZ_data.update_PVZ_version(3.2)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.3" in window_name:
-                PVZ_data.update_PVZ_version(3.3)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.4" in window_name:
-                PVZ_data.update_PVZ_version(3.4)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.5" in window_name:
-                PVZ_data.update_PVZ_version(3.5)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.6.5" in window_name:
-                PVZ_data.update_PVZ_version(3.65)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.6" in window_name:
-                PVZ_data.update_PVZ_version(3.6)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.7.5" in window_name:
-                PVZ_data.update_PVZ_version(3.75)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.7.6" in window_name:
-                PVZ_data.update_PVZ_version(3.76)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.7" in window_name:
-                PVZ_data.update_PVZ_version(3.7)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.8" in window_name:
-                PVZ_data.update_PVZ_version(3.8)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.9.9" in window_name:
-                PVZ_data.update_PVZ_version(3.99)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.9" in window_name:
-                PVZ_data.update_PVZ_version(3.9)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
+                    editor_runtime.main_window_title(current_version, PVZ_data.PVZ_version)
                 )
             PVZ_data.update_PVZ_memory(
                 Pymem(int(re.search(r"(\d+)", process1).group(1)))
@@ -525,282 +213,20 @@ def chooseGame():
 
     def tryFindGame():
         try:
-            hwnd = win32gui.FindWindow("MainWindow", None)
-            pid = win32process.GetWindowThreadProcessId(hwnd)
-            if "v2.0" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.0)
+            game_process = editor_runtime.find_running_game_process(
+                find_window=win32gui.FindWindow,
+                get_window_thread_process_id=win32process.GetWindowThreadProcessId,
+                get_window_text=win32gui.GetWindowText,
+                create_memory=Pymem,
+                get_process_name=lambda process_id: "",
+            )
+            if game_process.detected_version is not None:
+                PVZ_data.update_PVZ_version(game_process.detected_version)
                 main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
+                    editor_runtime.main_window_title(current_version, PVZ_data.PVZ_version)
                 )
-            elif "v2.1" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.1)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.2" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.2)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.35)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3.6" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.36)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3.7" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.37)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.3)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.4" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.4)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.5)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.6.1" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.61)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.6" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.6)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.17" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.17)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.16" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.16)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.15" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.151)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.14" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.14)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.13.2" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.132)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.12" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.12)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.11" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.11)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.0" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.0)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.1.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.15)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.1" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.1)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.2.1" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.21)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.2" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.2)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.3" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.3)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.4" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.4)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.5)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.6.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.65)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.6" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.6)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.7.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.75)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.7.6" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.76)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.7" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.7)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.8" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.8)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.9.9" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.99)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.9" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.9)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            PVZ_data.update_PVZ_memory(Pymem(pid[1]))
-            PVZ_data.update_PVZ_pid(pid[1])
+            PVZ_data.update_PVZ_memory(game_process.memory)
+            PVZ_data.update_PVZ_pid(game_process.process_id)
             choose_process_window.quit()
             choose_process_window.destroy()
         except:
@@ -1599,30 +1025,34 @@ def open_zombie_select_window(combobox):
 def mainWindow():
     global main_window
     main_window = ttk.Window()
-    main_window.title(
-        "杂交版多功能修改器  "
-        + str(current_version)
-        + "      游戏版本："
-        + str(PVZ_data.PVZ_version)
-    )
-    main_window.geometry("600x650")
+    main_window.title(editor_runtime.main_window_title(current_version, PVZ_data.PVZ_version))
     main_window.iconphoto(
         False, ttk.PhotoImage(file=resource_path(r"res\icon\editor.png"))
     )
     main_window.tk.call("tk", "scaling", 4 / 3)
+    main_window.minsize(
+        responsive_tk.MIN_WINDOW_WIDTH,
+        responsive_tk.MIN_WINDOW_HEIGHT,
+    )
 
-    def apply_window_position(file_path, window, section="main_window_position"):
+    def apply_window_geometry(file_path, window, section="main_window_position"):
         config = load_config(file_path)
         try:
             position = config.get(section, {})
-            x = position.get("x", 100)  # 默认值为100
-            y = position.get("y", 100)  # 默认值为100
-            window.geometry(f"+{x}+{y}")
+            saved_x = position.get("x") if isinstance(position.get("x"), int) else None
+            saved_y = position.get("y") if isinstance(position.get("y"), int) else None
+            geometry = responsive_tk.initial_window_geometry(
+                screen_width=window.winfo_screenwidth(),
+                screen_height=window.winfo_screenheight(),
+                saved_x=saved_x,
+                saved_y=saved_y,
+            )
+            window.geometry(geometry.as_tk_geometry())
         except:
             pass
 
     # 在主窗口创建后调用
-    apply_window_position(config_file_path, main_window)
+    apply_window_geometry(config_file_path, main_window)
 
     def open_update_window(latest_version):
         global main_window
@@ -1761,17 +1191,19 @@ def mainWindow():
     try:
         # 从服务器获取最新版本号
         response = requests.get(version_url)
-        latest_version = response.text.strip()
-        print(latest_version)
-        if latest_version == "The content may contain violation information":
+        update_decision = editor_runtime.evaluate_update_response(
+            current_version=current_version,
+            response_text=response.text,
+        )
+        print(update_decision.latest_version)
+        if update_decision.is_blocked:
             Messagebox.show_error(
                 "版本号被屏蔽",
                 title="更新检测失败",
             )
-        # 比较版本号
-        elif latest_version > current_version or latest_version == "0.74":
+        elif update_decision.should_open_update_window:
             # 如果发现新版本，提示用户
-            open_update_window(latest_version)
+            open_update_window(update_decision.latest_version)
     except Exception:
         Messagebox.show_error(
             "无法检查更新，请检查您的网络连接。",
@@ -1800,282 +1232,31 @@ def mainWindow():
 
     def tryFindGame():
         try:
-            hwnd = win32gui.FindWindow("MainWindow", None)
-            pid = win32process.GetWindowThreadProcessId(hwnd)
-            if "v2.0" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.0)
+            game_process = editor_runtime.find_running_game_process(
+                find_window=win32gui.FindWindow,
+                get_window_thread_process_id=win32process.GetWindowThreadProcessId,
+                get_window_text=win32gui.GetWindowText,
+                create_memory=Pymem,
+                get_process_name=lambda process_id: psutil.Process(process_id).name(),
+            )
+            if game_process.detected_version is not None:
+                PVZ_data.update_PVZ_version(game_process.detected_version)
                 main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
+                    editor_runtime.main_window_title(current_version, PVZ_data.PVZ_version)
                 )
-            elif "v2.1" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.1)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.2" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.2)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.35)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3.6" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.36)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3.7" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.37)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.3" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.3)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.4" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.4)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.6.1" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.61)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v2.6" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(2.6)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.0" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.0)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.17" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.17)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.16" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.16)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.15" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.151)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.14" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.14)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.13.2" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.132)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.12" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.12)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.11" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.11)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.1.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.15)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.1" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.1)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.2.1" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.21)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.2" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.2)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.3" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.3)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.4" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.4)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.5)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.6.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.65)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.6" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.6)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.7.5" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.75)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.7.6" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.76)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.7" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.7)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.8" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.8)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.9.9" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.99)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            elif "v3.9" in win32gui.GetWindowText(hwnd):
-                PVZ_data.update_PVZ_version(3.9)
-                main_window.title(
-                    "杂交版多功能修改器  "
-                    + str(current_version)
-                    + "      游戏版本："
-                    + str(PVZ_data.PVZ_version)
-                )
-            PVZ_data.update_PVZ_memory(Pymem(pid[1]))
-            PVZ_data.update_PVZ_pid(pid[1])
+            PVZ_data.update_PVZ_memory(game_process.memory)
+            PVZ_data.update_PVZ_pid(game_process.process_id)
             process_label["text"] = (
                 "找到进程："
-                + str(PVZ_data.PVZ_memory.process_id)
-                + str(psutil.Process(PVZ_data.PVZ_memory.process_id).name())
+                + str(game_process.process_id)
+                + str(game_process.process_name)
             )
             process_label.config(bootstyle=DANGER)
         except:
-            updateGame()
+            PVZ_data.update_PVZ_memory(0)
+            PVZ_data.update_PVZ_pid(0)
+            process_label["text"] = "未找到游戏"
+            process_label.config(bootstyle=DANGER)
 
     tryFindGame()
     choose_process_button = ttk.Button(
@@ -2097,8 +1278,16 @@ def mainWindow():
     )
     back_ground_check.place(x=3, y=-3, relx=0, rely=1, anchor=SW)
 
-    page_tab = ttk.Notebook(main_window)
-    page_tab.pack(padx=5, pady=(5, 25), fill=BOTH, expand=True)
+    main_viewport = responsive_tk.create_scrollable_viewport(
+        main_window,
+        ttk_module=ttk,
+        tk_module=tk,
+        min_content_width=900,
+        min_content_height=650,
+        bottom_margin=25,
+    )
+    page_tab = ttk.Notebook(main_viewport.frame)
+    page_tab.pack(fill=BOTH, expand=True)
     common_page = ttk.Frame(page_tab)
     common_page.pack()
     page_tab.add(common_page, text="常用功能")
@@ -2866,8 +2055,7 @@ def mainWindow():
     # 读取快捷键配置
 
     def get_shortcuts():
-        config = load_config(config_file_path)
-        return config.get("shortcuts", {})
+        return editor_config.get_shortcuts(config_file_path)
 
     # 移除所有当前的快捷键监听
     def remove_all_hotkeys():
@@ -2886,13 +2074,12 @@ def mainWindow():
 
     # 修改快捷键配置并重新加载监听
     def modify_shortcut(shortcut_id, new_key, new_action):
-        config = load_config(config_file_path)
-        # 保存旧的快捷键值
-        old_key = config["shortcuts"].get(shortcut_id, {}).get("key")
-        if "shortcuts" not in config:
-            config["shortcuts"] = {}
-        config["shortcuts"][shortcut_id] = {"key": new_key, "action": new_action}
-        save_config(config, config_file_path)
+        old_key = editor_config.set_shortcut(
+            config_file_path,
+            shortcut_id,
+            key=new_key,
+            action=new_action,
+        )
         # 如果旧的快捷键存在，则移除旧的快捷键监听
         if old_key:
             keyboard.remove_hotkey(old_key)

--- a/editor_config.py
+++ b/editor_config.py
@@ -1,0 +1,111 @@
+"""Typed configuration helpers for the PVZ Hybrid editor."""
+# ruff: noqa: UP007,UP045
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Optional, Union, cast
+
+import i18n
+
+APP_NAME = "PVZHybrid_Editor"
+Config = dict[str, Any]
+PathInput = Union[str, Path]
+
+_DEFAULT_CONFIG: Config = {
+    "language": i18n.DEFAULT_LANGUAGE,
+    "shortcuts": {
+        "key1": {"key": "ctrl+space", "action": 0},
+        "key2": {"key": "Ctrl+f2", "action": 1},
+        "key3": {"key": "Ctrl+f3", "action": 2},
+        "key4": {"key": "Ctrl+f4", "action": 3},
+        "key5": {"key": "Ctrl+f5", "action": 4},
+        "key6": {"key": "Ctrl+f6", "action": 5},
+        "key7": {"key": "Ctrl+f7", "action": 6},
+        "key8": {"key": "Ctrl+f8", "action": 7},
+        "key9": {"key": "Ctrl+f9", "action": 8},
+        "key10": {"key": "Ctrl+f10", "action": 9},
+        "key11": {"key": "Ctrl+f11", "action": 10},
+        "key12": {"key": "Ctrl+f12", "action": 11},
+    },
+}
+
+
+def default_config() -> Config:
+    return copy.deepcopy(_DEFAULT_CONFIG)
+
+
+def app_config_path(appdata_root: Optional[PathInput], app_name: str = APP_NAME) -> Path:
+    if appdata_root is None:
+        raise RuntimeError("APPDATA is required for PVZHybrid_Editor config")
+    return Path(appdata_root) / app_name
+
+
+def config_file_path(appdata_root: Optional[PathInput], app_name: str = APP_NAME) -> Path:
+    return app_config_path(appdata_root, app_name=app_name) / "config.json"
+
+
+def create_config(path: PathInput, config: Optional[Config] = None) -> None:
+    save_config(default_config() if config is None else config, path)
+
+
+def load_config(path: PathInput) -> Config:
+    try:
+        with Path(path).open(encoding="utf-8") as file:
+            payload = json.load(file)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default_config()
+    if not isinstance(payload, dict):
+        return default_config()
+    return cast(Config, payload)
+
+
+def save_config(config: Config, path: PathInput) -> None:
+    config_path = Path(path)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with config_path.open("w", encoding="utf-8") as file:
+        json.dump(config, file, indent=4, ensure_ascii=False)
+
+
+def modify_config(path: PathInput, section: str, key: str, value: Any) -> None:
+    config = load_config(path)
+    section_value = config.get(section)
+    if not isinstance(section_value, dict):
+        section_value = {}
+        config[section] = section_value
+    section_value[key] = value
+    save_config(config, path)
+
+
+def get_config_language(path: PathInput) -> str:
+    language = load_config(path).get("language")
+    return i18n.safe_language(language if isinstance(language, str) else None)
+
+
+def set_config_language(path: PathInput, language: str) -> None:
+    config = load_config(path)
+    config["language"] = i18n.normalize_language(language)
+    save_config(config, path)
+
+
+def get_shortcuts(path: PathInput) -> Config:
+    shortcuts = load_config(path).get("shortcuts", {})
+    if isinstance(shortcuts, dict):
+        return cast(Config, shortcuts)
+    return {}
+
+
+def set_shortcut(path: PathInput, shortcut_id: str, *, key: str, action: int) -> Optional[str]:
+    config = load_config(path)
+    shortcuts = config.get("shortcuts")
+    if not isinstance(shortcuts, dict):
+        shortcuts = {}
+        config["shortcuts"] = shortcuts
+
+    old_shortcut = shortcuts.get(shortcut_id)
+    old_key = old_shortcut.get("key") if isinstance(old_shortcut, dict) else None
+    shortcuts[shortcut_id] = {"key": key, "action": action}
+    save_config(config, path)
+    return old_key if isinstance(old_key, str) else None

--- a/editor_layout_audit.py
+++ b/editor_layout_audit.py
@@ -13,7 +13,10 @@ class MainWindowLayout:
     sets_minimum_window_size: bool
     uses_initial_window_geometry: bool
     uses_scrollable_viewport: bool
+    uses_bottom_bar: bool
     notebook_parent: str | None
+    bottom_control_parents: dict[str, str | None]
+    bottom_control_geometry_managers: dict[str, list[str]]
     literal_geometries: set[str]
 
 
@@ -40,7 +43,13 @@ def inspect_main_window_layout(path: Path) -> MainWindowLayout:
         sets_minimum_window_size=visitor.sets_minimum_window_size,
         uses_initial_window_geometry=visitor.uses_initial_window_geometry,
         uses_scrollable_viewport=visitor.uses_scrollable_viewport,
+        uses_bottom_bar=visitor.uses_bottom_bar,
         notebook_parent=visitor.notebook_parent,
+        bottom_control_parents=visitor.bottom_control_parents,
+        bottom_control_geometry_managers={
+            name: sorted(managers)
+            for name, managers in visitor.bottom_control_geometry_managers.items()
+        },
         literal_geometries=visitor.literal_geometries,
     )
 
@@ -73,7 +82,10 @@ class _LayoutVisitor(ast.NodeVisitor):
         self.sets_minimum_window_size = False
         self.uses_initial_window_geometry = False
         self.uses_scrollable_viewport = False
+        self.uses_bottom_bar = False
         self.notebook_parent: str | None = None
+        self.bottom_control_parents: dict[str, str | None] = {}
+        self.bottom_control_geometry_managers: dict[str, set[str]] = {}
         self.literal_geometries: set[str] = set()
         self._inside_main_window = False
 
@@ -99,9 +111,12 @@ class _LayoutVisitor(ast.NodeVisitor):
             self.uses_scrollable_viewport = True
         elif call_name == "main_window.geometry":
             self._collect_literal_geometry(node)
+        elif call_name is not None:
+            self._collect_bottom_control_geometry_manager(call_name)
         self.generic_visit(node)
 
     def visit_Assign(self, node: ast.Assign) -> None:
+        self._collect_bottom_control_parent(node)
         if _assigns_name(node, "page_tab") and isinstance(node.value, ast.Call):
             call_name = _call_name(node.value.func)
             if call_name == "ttk.Notebook" and node.value.args:
@@ -112,6 +127,29 @@ class _LayoutVisitor(ast.NodeVisitor):
         first_arg = node.args[0] if node.args else None
         if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
             self.literal_geometries.add(first_arg.value)
+
+    def _collect_bottom_control_parent(self, node: ast.Assign) -> None:
+        if not self._inside_main_window or not isinstance(node.value, ast.Call):
+            return
+        for name in _assigned_names(node):
+            if name == "bottom_bar":
+                self.uses_bottom_bar = True
+            if name not in _BOTTOM_CONTROLS:
+                continue
+            parent = _call_name(node.value.args[0]) if node.value.args else None
+            self.bottom_control_parents[name] = parent
+
+    def _collect_bottom_control_geometry_manager(self, call_name: str) -> None:
+        if not self._inside_main_window:
+            return
+        for control_name in _BOTTOM_CONTROLS:
+            prefix = f"{control_name}."
+            if not call_name.startswith(prefix):
+                continue
+            manager = call_name.removeprefix(prefix)
+            if manager not in {"pack", "place", "grid"}:
+                continue
+            self.bottom_control_geometry_managers.setdefault(control_name, set()).add(manager)
 
 
 class _GameDetectionVisitor(ast.NodeVisitor):
@@ -210,6 +248,10 @@ def _assigns_name(node: ast.Assign, name: str) -> bool:
     return any(isinstance(target, ast.Name) and target.id == name for target in node.targets)
 
 
+def _assigned_names(node: ast.Assign) -> set[str]:
+    return {target.id for target in node.targets if isinstance(target, ast.Name)}
+
+
 def _assigns_process_label_not_found(node: ast.AST) -> bool:
     if not isinstance(node, ast.Assign):
         return False
@@ -219,3 +261,14 @@ def _assigns_process_label_not_found(node: ast.AST) -> bool:
         isinstance(target, ast.Subscript) and _call_name(target.value) == "process_label"
         for target in node.targets
     )
+
+
+_BOTTOM_CONTROLS = frozenset(
+    {
+        "process_frame",
+        "back_ground_check",
+        "plugin_button",
+        "unsupported_label",
+        "language_frame",
+    }
+)

--- a/editor_layout_audit.py
+++ b/editor_layout_audit.py
@@ -1,0 +1,221 @@
+"""Static layout checks for the Windows-only editor module."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class MainWindowLayout:
+    imports_responsive_tk: bool
+    sets_minimum_window_size: bool
+    uses_initial_window_geometry: bool
+    uses_scrollable_viewport: bool
+    notebook_parent: str | None
+    literal_geometries: set[str]
+
+
+@dataclass(frozen=True)
+class GameDetectionAudit:
+    detect_game_version_calls: int
+    find_running_game_process_calls: int
+    legacy_window_name_version_checks: set[str]
+    legacy_win32_window_text_version_checks: set[str]
+
+
+@dataclass(frozen=True)
+class StartupGameSearchAudit:
+    calls_update_game_on_failure: bool
+    sets_not_found_status_on_failure: bool
+
+
+def inspect_main_window_layout(path: Path) -> MainWindowLayout:
+    tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+    visitor = _LayoutVisitor()
+    visitor.visit(tree)
+    return MainWindowLayout(
+        imports_responsive_tk=visitor.imports_responsive_tk,
+        sets_minimum_window_size=visitor.sets_minimum_window_size,
+        uses_initial_window_geometry=visitor.uses_initial_window_geometry,
+        uses_scrollable_viewport=visitor.uses_scrollable_viewport,
+        notebook_parent=visitor.notebook_parent,
+        literal_geometries=visitor.literal_geometries,
+    )
+
+
+def inspect_game_detection(path: Path) -> GameDetectionAudit:
+    tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+    visitor = _GameDetectionVisitor()
+    visitor.visit(tree)
+    return GameDetectionAudit(
+        detect_game_version_calls=visitor.detect_game_version_calls,
+        find_running_game_process_calls=visitor.find_running_game_process_calls,
+        legacy_window_name_version_checks=visitor.legacy_window_name_version_checks,
+        legacy_win32_window_text_version_checks=visitor.legacy_win32_window_text_version_checks,
+    )
+
+
+def inspect_startup_game_search(path: Path) -> StartupGameSearchAudit:
+    tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+    visitor = _StartupGameSearchVisitor()
+    visitor.visit(tree)
+    return StartupGameSearchAudit(
+        calls_update_game_on_failure=visitor.calls_update_game_on_failure,
+        sets_not_found_status_on_failure=visitor.sets_not_found_status_on_failure,
+    )
+
+
+class _LayoutVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.imports_responsive_tk = False
+        self.sets_minimum_window_size = False
+        self.uses_initial_window_geometry = False
+        self.uses_scrollable_viewport = False
+        self.notebook_parent: str | None = None
+        self.literal_geometries: set[str] = set()
+        self._inside_main_window = False
+
+    def visit_Import(self, node: ast.Import) -> None:
+        if any(alias.name == "responsive_tk" for alias in node.names):
+            self.imports_responsive_tk = True
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if node.name == "mainWindow" or self._inside_main_window:
+            was_inside_main_window = self._inside_main_window
+            self._inside_main_window = True
+            self.generic_visit(node)
+            self._inside_main_window = was_inside_main_window
+
+    def visit_Call(self, node: ast.Call) -> None:
+        call_name = _call_name(node.func)
+        if call_name == "main_window.minsize":
+            self.sets_minimum_window_size = True
+        elif call_name == "responsive_tk.initial_window_geometry":
+            self.uses_initial_window_geometry = True
+        elif call_name == "responsive_tk.create_scrollable_viewport":
+            self.uses_scrollable_viewport = True
+        elif call_name == "main_window.geometry":
+            self._collect_literal_geometry(node)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if _assigns_name(node, "page_tab") and isinstance(node.value, ast.Call):
+            call_name = _call_name(node.value.func)
+            if call_name == "ttk.Notebook" and node.value.args:
+                self.notebook_parent = _call_name(node.value.args[0])
+        self.generic_visit(node)
+
+    def _collect_literal_geometry(self, node: ast.Call) -> None:
+        first_arg = node.args[0] if node.args else None
+        if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
+            self.literal_geometries.add(first_arg.value)
+
+
+class _GameDetectionVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.detect_game_version_calls = 0
+        self.find_running_game_process_calls = 0
+        self.legacy_window_name_version_checks: set[str] = set()
+        self.legacy_win32_window_text_version_checks: set[str] = set()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        call_name = _call_name(node.func)
+        if call_name == "editor_runtime.detect_game_version":
+            self.detect_game_version_calls += 1
+        elif call_name == "editor_runtime.find_running_game_process":
+            self.find_running_game_process_calls += 1
+        self.generic_visit(node)
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        marker = _version_marker(node.left)
+        if marker is None:
+            self.generic_visit(node)
+            return
+
+        for operator, comparator in zip(node.ops, node.comparators, strict=True):
+            if not isinstance(operator, ast.In):
+                continue
+            comparator_name = (
+                _call_name(comparator.func)
+                if isinstance(comparator, ast.Call)
+                else _call_name(comparator)
+            )
+            if comparator_name == "window_name":
+                self.legacy_window_name_version_checks.add(marker)
+            elif comparator_name == "win32gui.GetWindowText":
+                self.legacy_win32_window_text_version_checks.add(marker)
+        self.generic_visit(node)
+
+
+class _StartupGameSearchVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.calls_update_game_on_failure = False
+        self.sets_not_found_status_on_failure = False
+        self._inside_main_window = False
+        self._inside_startup_try_find_game = False
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if node.name == "mainWindow":
+            was_inside_main_window = self._inside_main_window
+            self._inside_main_window = True
+            self.generic_visit(node)
+            self._inside_main_window = was_inside_main_window
+            return
+
+        if self._inside_main_window and node.name == "tryFindGame":
+            was_inside_startup_try_find_game = self._inside_startup_try_find_game
+            self._inside_startup_try_find_game = True
+            self.generic_visit(node)
+            self._inside_startup_try_find_game = was_inside_startup_try_find_game
+            return
+
+        self.generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if not self._inside_startup_try_find_game:
+            self.generic_visit(node)
+            return
+
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call) and _call_name(child.func) == "updateGame":
+                self.calls_update_game_on_failure = True
+            if _assigns_process_label_not_found(child):
+                self.sets_not_found_status_on_failure = True
+        self.generic_visit(node)
+
+
+def _call_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _call_name(node.value)
+        if parent is None:
+            return node.attr
+        return f"{parent}.{node.attr}"
+    return None
+
+
+def _version_marker(node: ast.AST) -> str | None:
+    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+        return None
+    if node.value.startswith("v") and any(char.isdigit() for char in node.value):
+        return node.value
+    return None
+
+
+def _assigns_name(node: ast.Assign, name: str) -> bool:
+    return any(isinstance(target, ast.Name) and target.id == name for target in node.targets)
+
+
+def _assigns_process_label_not_found(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Assign):
+        return False
+    if not isinstance(node.value, ast.Constant) or node.value.value != "未找到游戏":
+        return False
+    return any(
+        isinstance(target, ast.Subscript) and _call_name(target.value) == "process_label"
+        for target in node.targets
+    )

--- a/editor_runtime.py
+++ b/editor_runtime.py
@@ -1,0 +1,166 @@
+"""Runtime path and title helpers for the PVZ Hybrid editor."""
+# ruff: noqa: UP007,UP045
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Union
+
+PathInput = Union[str, Path]
+DEFAULT_GAME_VERSION = "Game not found"
+BLOCKED_UPDATE_RESPONSE = "The content may contain violation information"
+LEGACY_UPDATE_VERSION = "0.74"
+GAME_VERSION_MARKERS = (
+    ("v3.13.2", 3.132),
+    ("v3.9.9", 3.99),
+    ("v3.7.6", 3.76),
+    ("v3.7.5", 3.75),
+    ("v3.6.5", 3.65),
+    ("v3.2.1", 3.21),
+    ("v3.1.5", 3.15),
+    ("v2.6.1", 2.61),
+    ("v2.3.7", 2.37),
+    ("v2.3.6", 2.36),
+    ("v2.3.5", 2.35),
+    ("v3.17", 3.17),
+    ("v3.16", 3.16),
+    ("v3.15", 3.151),
+    ("v3.14", 3.14),
+    ("v3.12", 3.12),
+    ("v3.11", 3.11),
+    ("v3.10", 3.10),
+    ("v3.9", 3.9),
+    ("v3.8", 3.8),
+    ("v3.7", 3.7),
+    ("v3.6", 3.6),
+    ("v3.5", 3.5),
+    ("v3.4", 3.4),
+    ("v3.3", 3.3),
+    ("v3.2", 3.2),
+    ("v3.1", 3.1),
+    ("v3.0", 3.0),
+    ("v2.6", 2.6),
+    ("v2.5", 2.5),
+    ("v2.4", 2.4),
+    ("v2.3", 2.3),
+    ("v2.2", 2.2),
+    ("v2.1", 2.1),
+    ("v2.0", 2.0),
+)
+
+
+@dataclass(frozen=True)
+class RunningGameProcess:
+    process_id: int
+    window_title: str
+    detected_version: Optional[float]
+    memory: Any
+    process_name: str
+
+
+@dataclass(frozen=True)
+class UpdateDecision:
+    latest_version: str
+    is_blocked: bool
+    should_open_update_window: bool
+
+
+class GameProcessNotFound(LookupError):
+    pass
+
+
+def resource_path(
+    relative_path: PathInput,
+    *,
+    runtime: Any = None,
+    base_dir: Optional[PathInput] = None,
+) -> str:
+    if base_dir is None:
+        bundle_dir = getattr(runtime, "_MEIPASS", None)
+        base_path = Path(bundle_dir) if bundle_dir else Path(os.path.abspath("."))
+    else:
+        base_path = Path(base_dir)
+    return str(base_path / relative_path)
+
+
+def main_window_title(editor_version: object, game_version: object = DEFAULT_GAME_VERSION) -> str:
+    resolved_game_version = DEFAULT_GAME_VERSION if game_version is None else game_version
+    return f"杂交版多功能修改器  {editor_version}      游戏版本：{resolved_game_version}"
+
+
+def detect_game_version(window_title: str) -> Optional[float]:
+    for marker, version in GAME_VERSION_MARKERS:
+        if marker in window_title:
+            return version
+    return None
+
+
+def find_running_game_process(
+    *,
+    find_window: Callable[[str, object | None], int],
+    get_window_thread_process_id: Callable[[int], tuple[int, int]],
+    get_window_text: Callable[[int], str],
+    create_memory: Callable[[int], Any],
+    get_process_name: Callable[[int], str],
+) -> RunningGameProcess:
+    hwnd = find_window("MainWindow", None)
+    if not hwnd:
+        raise GameProcessNotFound("PVZ Hybrid game window not found")
+
+    _thread_id, process_id = get_window_thread_process_id(hwnd)
+    window_title = get_window_text(hwnd)
+    return RunningGameProcess(
+        process_id=process_id,
+        window_title=window_title,
+        detected_version=detect_game_version(window_title),
+        memory=create_memory(process_id),
+        process_name=get_process_name(process_id),
+    )
+
+
+def evaluate_update_response(*, current_version: str, response_text: str) -> UpdateDecision:
+    latest_version = response_text.strip()
+    is_blocked = latest_version == BLOCKED_UPDATE_RESPONSE
+    return UpdateDecision(
+        latest_version=latest_version,
+        is_blocked=is_blocked,
+        should_open_update_window=(
+            False
+            if is_blocked
+            else should_open_update_window(current_version, latest_version)
+        ),
+    )
+
+
+def should_open_update_window(current_version: str, latest_version: str) -> bool:
+    if latest_version == LEGACY_UPDATE_VERSION:
+        return True
+
+    current_parts = _parse_numeric_release(current_version)
+    latest_parts = _parse_numeric_release(latest_version)
+    if current_parts is None or latest_parts is None:
+        return latest_version > current_version
+
+    current_padded, latest_padded = _pad_release_parts(current_parts, latest_parts)
+    return latest_padded > current_padded
+
+
+def _parse_numeric_release(version: str) -> tuple[int, ...] | None:
+    parts = version.split(".")
+    if not parts or any(not part.isdigit() for part in parts):
+        return None
+    return tuple(int(part) for part in parts)
+
+
+def _pad_release_parts(
+    current_parts: tuple[int, ...],
+    latest_parts: tuple[int, ...],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    max_length = max(len(current_parts), len(latest_parts))
+    return (
+        current_parts + (0,) * (max_length - len(current_parts)),
+        latest_parts + (0,) * (max_length - len(latest_parts)),
+    )

--- a/editor_ui_smoke.py
+++ b/editor_ui_smoke.py
@@ -1,0 +1,239 @@
+"""Launch the real editor window on Windows and capture a responsive UI screenshot."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import responsive_ui_smoke
+
+SCREENSHOT_NAME = "editor-ui-smoke.png"
+AUDIT_NAME = "editor-ui-smoke.json"
+MIN_SCREENSHOT_BYTES = 100
+SMOKE_GAME_VERSION = 3.17
+
+
+@dataclass(frozen=True)
+class EditorSmokeAudit:
+    screenshot_name: str
+    screenshot_size_bytes: int
+    screenshot_varies: bool
+    window_width: int
+    window_height: int
+    notebook_width: int
+    notebook_height: int
+    title: str
+    scrollbar_count: int
+    scrollbars_available: bool
+
+
+def build_editor_audit(
+    *,
+    screenshot_path: Path,
+    screenshot_size_bytes: int,
+    screenshot_varies: bool,
+    window_width: int,
+    window_height: int,
+    notebook_width: int,
+    notebook_height: int,
+    title: str,
+    scrollbar_count: int,
+) -> EditorSmokeAudit:
+    return EditorSmokeAudit(
+        screenshot_name=screenshot_path.name,
+        screenshot_size_bytes=screenshot_size_bytes,
+        screenshot_varies=screenshot_varies,
+        window_width=window_width,
+        window_height=window_height,
+        notebook_width=notebook_width,
+        notebook_height=notebook_height,
+        title=title,
+        scrollbar_count=scrollbar_count,
+        scrollbars_available=scrollbar_count >= 2,
+    )
+
+
+def write_audit(path: Path, audit: EditorSmokeAudit) -> None:
+    path.write_text(
+        json.dumps(asdict(audit), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def assert_editor_screenshot_evidence(path: Path, *, screenshot_varies: bool) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"editor UI screenshot missing: {path}")
+    if path.stat().st_size < MIN_SCREENSHOT_BYTES:
+        raise ValueError(f"editor UI screenshot too small: {path}")
+    if not screenshot_varies:
+        raise ValueError("editor UI smoke captured a blank screenshot")
+
+
+def find_first_widget_by_class(widget: Any, widget_class: str) -> Any | None:
+    if widget.winfo_class() == widget_class:
+        return widget
+    for child in widget.winfo_children():
+        found = find_first_widget_by_class(child, widget_class)
+        if found is not None:
+            return found
+    return None
+
+
+def count_widgets_by_class(widget: Any, widget_class: str) -> int:
+    count = 1 if widget.winfo_class() == widget_class else 0
+    for child in widget.winfo_children():
+        count += count_widgets_by_class(child, widget_class)
+    return count
+
+
+def run_editor_smoke(output_dir: Path) -> EditorSmokeAudit:  # pragma: no cover - Windows GUI
+    from PIL import ImageGrab  # type: ignore[import-not-found]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    screenshot_path = output_dir / SCREENSHOT_NAME
+    audit_path = output_dir / AUDIT_NAME
+    captured: dict[str, EditorSmokeAudit] = {}
+
+    editor_module = importlib.import_module("editor")
+
+    _patch_editor_runtime(editor_module)
+    original_window_factory = editor_module.ttk.Window
+
+    def smoke_window_factory(*args: object, **kwargs: object) -> Any:
+        window = original_window_factory(*args, **kwargs)
+        original_mainloop = window.mainloop
+
+        def smoke_mainloop(*mainloop_args: object, **mainloop_kwargs: object) -> object:
+            window.after(1500, lambda: _capture_and_close(window))
+            return original_mainloop(*mainloop_args, **mainloop_kwargs)
+
+        window.mainloop = smoke_mainloop
+        return window
+
+    def _capture_and_close(window: Any) -> None:
+        window.update_idletasks()
+        window.update()
+
+        left = window.winfo_rootx()
+        top = window.winfo_rooty()
+        right = left + window.winfo_width()
+        bottom = top + window.winfo_height()
+        image = ImageGrab.grab(bbox=(left, top, right, bottom)).convert("RGB")
+        screenshot_varies = responsive_ui_smoke._image_has_pixel_variation(image)
+        image.save(screenshot_path)
+
+        notebook = find_first_widget_by_class(window, "TNotebook")
+        scrollbar_count = count_widgets_by_class(window, "TScrollbar")
+        audit = build_editor_audit(
+            screenshot_path=screenshot_path,
+            screenshot_size_bytes=screenshot_path.stat().st_size,
+            screenshot_varies=screenshot_varies,
+            window_width=window.winfo_width(),
+            window_height=window.winfo_height(),
+            notebook_width=notebook.winfo_width() if notebook is not None else 0,
+            notebook_height=notebook.winfo_height() if notebook is not None else 0,
+            title=window.title(),
+            scrollbar_count=scrollbar_count,
+        )
+        assert_editor_screenshot_evidence(screenshot_path, screenshot_varies=screenshot_varies)
+        write_audit(audit_path, audit)
+        captured["audit"] = audit
+        window.destroy()
+
+    editor_module.ttk.Window = smoke_window_factory
+    try:
+        editor_module.mainWindow()
+    finally:
+        editor_module.ttk.Window = original_window_factory
+
+    return captured["audit"]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    run_editor_smoke(args.output_dir)
+    return 0
+
+
+def _patch_editor_runtime(editor_module: Any) -> None:  # pragma: no cover - Windows GUI
+    class SmokePVZMemory:
+        def __init__(self, process_id: int = 1234) -> None:
+            self.process_id = process_id
+
+        def read_uint(self, address: int) -> int:
+            if address in {0x41C965, 0x41C905}:
+                return 304
+            return 0
+
+        def read_ushort(self, address: int) -> int:
+            return 0
+
+        def read_uchar(self, address: int) -> int:
+            return 0
+
+        def read_bool(self, address: int) -> bool:
+            return False
+
+        def read_float(self, address: int) -> float:
+            return 0.0
+
+        def read_bytes(self, address: int, length: int) -> bytes:
+            return b"\x00" * length
+
+        def write_int(self, address: int, value: object) -> None:
+            return None
+
+        def write_float(self, address: int, value: object) -> None:
+            return None
+
+        def write_bool(self, address: int, value: object) -> None:
+            return None
+
+        def write_ushort(self, address: int, value: object) -> None:
+            return None
+
+        def write_uchar(self, address: int, value: object) -> None:
+            return None
+
+        def write_bytes(self, address: int, value: object, length: int | None = None) -> None:
+            return None
+
+    class SmokeProcess:
+        def __init__(self, process_id: int) -> None:
+            self.process_id = process_id
+
+        def name(self) -> str:
+            return "PVZHybrid.exe"
+
+    class Response:
+        text = str(editor_module.current_version)
+
+    editor_module.PVZ_data.update_PVZ_memory(SmokePVZMemory())
+    editor_module.PVZ_data.update_PVZ_version(SMOKE_GAME_VERSION)
+    editor_module.Pymem = SmokePVZMemory
+    editor_module.win32gui.FindWindow = lambda *args, **kwargs: 1
+    editor_module.win32gui.GetWindowText = lambda *args, **kwargs: "v3.17"
+    editor_module.win32process.GetWindowThreadProcessId = lambda *args, **kwargs: (0, 1234)
+    editor_module.psutil.Process = SmokeProcess
+    editor_module.requests.get = lambda *args, **kwargs: Response()
+    editor_module.Messagebox.show_error = lambda *args, **kwargs: None
+    editor_module.keyboard.add_hotkey = lambda *args, **kwargs: None
+    editor_module.keyboard.remove_hotkey = lambda *args, **kwargs: None
+
+    editor_module.pvz.getShovel = lambda: 0
+    editor_module.pvz.getMap = lambda: False
+    editor_module.pvz.getSun = lambda: 0
+    editor_module.pvz.getSilver = lambda: 0
+    editor_module.pvz.getGold = lambda: 0
+    editor_module.pvz.getDiamond = lambda: 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/i18n.py
+++ b/i18n.py
@@ -7,7 +7,7 @@ import weakref
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 DEFAULT_LANGUAGE = "zh_CN"
 LANGUAGE_ORDER = ("zh_CN", "en", "es", "fr", "de", "ja", "ko", "ru")
@@ -38,7 +38,7 @@ _current_language = DEFAULT_LANGUAGE
 _widgets: weakref.WeakKeyDictionary[Any, dict[str, Any]] = weakref.WeakKeyDictionary()
 _notebooks: weakref.WeakKeyDictionary[Any, dict[Any, str]] = weakref.WeakKeyDictionary()
 _window_titles: weakref.WeakKeyDictionary[Any, str] = weakref.WeakKeyDictionary()
-_patched_modules: set[int] = set()
+_patched_modules: weakref.WeakSet[Any] = weakref.WeakSet()
 
 
 def supported_languages() -> list[Language]:
@@ -179,7 +179,7 @@ def refresh_widgets(root: Any | None = None) -> None:
 
 def install_tk_i18n(ttk_module: Any, tk_module: Any | None = None) -> None:
     for module in (ttk_module, tk_module):
-        if module is None or id(module) in _patched_modules:
+        if module is None or module in _patched_modules:
             continue
         for class_name in (
             "Button",
@@ -197,13 +197,13 @@ def install_tk_i18n(ttk_module: Any, tk_module: Any | None = None) -> None:
             "Tk",
         ):
             _patch_widget_factory(module, class_name)
-        _patched_modules.add(id(module))
+        _patched_modules.add(module)
 
 
 def _load_locale_payload(code: str) -> dict[str, Any]:
     path = LOCALES_DIR / f"{code}.json"
     with path.open("r", encoding="utf-8") as file:
-        payload = json.load(file)
+        payload = cast(dict[str, Any], json.load(file))
     if payload.get("code") != code:
         raise ValueError(f"Locale code mismatch in {path}")
     return payload
@@ -238,7 +238,7 @@ def _apply_widget_translation(widget: Any, metadata: dict[str, Any]) -> None:
     if "values" in metadata:
         selected_source = _get_selected_source(widget)
         updates["values"] = translate_values(metadata["values"])
-    if updates:
+    if updates:  # pragma: no branch
         widget.configure(**updates)
     if "values" in metadata and selected_source in metadata["values"]:
         _set_selected_source(widget, selected_source)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ files = [
 disallow_untyped_defs = true
 check_untyped_defs = true
 warn_return_any = true
+strict = true
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,39 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B"]
+
+[tool.mypy]
+python_version = "3.11"
+files = [
+  "editor_config.py",
+  "editor_ui_smoke.py",
+  "i18n.py",
+  "i18n_audit.py",
+  "editor_layout_audit.py",
+  "editor_runtime.py",
+  "release_package.py",
+  "responsive_tk.py",
+  "responsive_ui_smoke.py",
+]
+disallow_untyped_defs = true
+check_untyped_defs = true
+warn_return_any = true
+
+[tool.coverage.run]
+branch = true
+source = [
+  "editor_config",
+  "editor_ui_smoke",
+  "i18n",
+  "i18n_audit",
+  "editor_layout_audit",
+  "editor_runtime",
+  "release_package",
+  "responsive_tk",
+  "responsive_ui_smoke",
+]
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+skip_covered = true

--- a/release_package.py
+++ b/release_package.py
@@ -1,0 +1,143 @@
+"""Prepare GitHub Actions release artifacts for the Windows executable."""
+# ruff: noqa: UP017,UP045
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+APP_NAME = "PVZHybrid_Editor"
+DEFAULT_PLATFORM_TAG = "win7_x86"
+
+
+@dataclass(frozen=True)
+class ReleasePackage:
+    exe_name: str
+    manifest_name: str
+    sha_name: str
+    exe_path: Path
+    manifest_path: Path
+    sha_path: Path
+    sha256: str
+    size_bytes: int
+    size_mb: float
+    date_label: str
+
+
+def read_version(path: Path) -> str:
+    version = path.read_text(encoding="utf-8").strip()
+    if not version:
+        raise ValueError("version.txt is empty")
+    return version
+
+
+def executable_name(version: str, platform_tag: str = DEFAULT_PLATFORM_TAG) -> str:
+    return f"{platform_tag}.{APP_NAME}_b{version}.exe"
+
+
+def prepare_release_package(
+    *,
+    dist_dir: Path,
+    version: str,
+    built_at: date,
+    github_output: Optional[Path] = None,
+    platform_tag: str = DEFAULT_PLATFORM_TAG,
+) -> ReleasePackage:
+    exe_name = executable_name(version, platform_tag=platform_tag)
+    exe_path = dist_dir / exe_name
+    if not exe_path.exists():
+        raise FileNotFoundError(f"Expected executable missing: {exe_path}")
+
+    payload = exe_path.read_bytes()
+    sha256 = hashlib.sha256(payload).hexdigest()
+    size_bytes = len(payload)
+    size_mb = round(size_bytes / (1024 * 1024), 1)
+    date_label = f"{built_at:%b} {built_at.day}"
+
+    manifest_name = f"{exe_name}.txt"
+    sha_name = f"{exe_name}.sha256"
+    manifest_path = dist_dir / manifest_name
+    sha_path = dist_dir / sha_name
+
+    manifest_path.write_text(
+        "\n".join(
+            [
+                exe_name,
+                f"sha256:{sha256}",
+                str(size_bytes),
+                f"{size_mb:.1f} MB",
+                date_label,
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sha_path.write_text(f"sha256:{sha256}  {exe_name}\n", encoding="ascii")
+
+    package = ReleasePackage(
+        exe_name=exe_name,
+        manifest_name=manifest_name,
+        sha_name=sha_name,
+        exe_path=exe_path,
+        manifest_path=manifest_path,
+        sha_path=sha_path,
+        sha256=sha256,
+        size_bytes=size_bytes,
+        size_mb=size_mb,
+        date_label=date_label,
+    )
+    if github_output is not None:
+        write_github_output(github_output, package)
+    return package
+
+
+def write_github_output(path: Path, package: ReleasePackage) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        output.write(
+            "\n".join(
+                [
+                    f"exe_name={package.exe_name}",
+                    f"manifest_name={package.manifest_name}",
+                    f"sha_name={package.sha_name}",
+                    f"exe_path={package.exe_path}",
+                    f"manifest_path={package.manifest_path}",
+                    f"sha_path={package.sha_path}",
+                ]
+            )
+            + "\n"
+        )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dist-dir", type=Path, required=True)
+    parser.add_argument("--version-file", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--platform-tag", default=DEFAULT_PLATFORM_TAG)
+    parser.add_argument("--built-at")
+    args = parser.parse_args(argv)
+
+    built_at = _parse_date(args.built_at)
+    prepare_release_package(
+        dist_dir=args.dist_dir,
+        version=read_version(args.version_file),
+        built_at=built_at,
+        github_output=args.github_output,
+        platform_tag=args.platform_tag,
+    )
+    return 0
+
+
+def _parse_date(value: Optional[str]) -> date:
+    if value is None:
+        return datetime.now(timezone.utc).date()
+    return date.fromisoformat(value)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/release_package.py
+++ b/release_package.py
@@ -37,7 +37,8 @@ def read_version(path: Path) -> str:
 
 
 def executable_name(version: str, platform_tag: str = DEFAULT_PLATFORM_TAG) -> str:
-    return f"{platform_tag}.{APP_NAME}_b{version}.exe"
+    prefix = f"{platform_tag}." if platform_tag else ""
+    return f"{prefix}{APP_NAME}_b{version}.exe"
 
 
 def prepare_release_package(
@@ -116,19 +117,31 @@ def write_github_output(path: Path, package: ReleasePackage) -> None:
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dist-dir", type=Path, required=True)
-    parser.add_argument("--version-file", type=Path, required=True)
+    version_group = parser.add_mutually_exclusive_group(required=True)
+    version_group.add_argument("--version-file", type=Path)
+    version_group.add_argument("--version")
     parser.add_argument("--github-output", type=Path)
-    parser.add_argument("--platform-tag", default=DEFAULT_PLATFORM_TAG)
+    platform_group = parser.add_mutually_exclusive_group()
+    platform_group.add_argument("--platform-tag", default=DEFAULT_PLATFORM_TAG)
+    platform_group.add_argument("--no-platform-tag", action="store_true")
     parser.add_argument("--built-at")
     args = parser.parse_args(argv)
+
+    version = args.version
+    if version is not None:
+        version = version.strip()
+        if not version:
+            raise ValueError("version is empty")
+    else:
+        version = read_version(args.version_file)
 
     built_at = _parse_date(args.built_at)
     prepare_release_package(
         dist_dir=args.dist_dir,
-        version=read_version(args.version_file),
+        version=version,
         built_at=built_at,
         github_output=args.github_output,
-        platform_tag=args.platform_tag,
+        platform_tag="" if args.no_platform_tag else args.platform_tag,
     )
     return 0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest>=8.0
 ruff>=0.6
+mypy>=1.18
+coverage[toml]>=7.6

--- a/responsive_tk.py
+++ b/responsive_tk.py
@@ -1,0 +1,134 @@
+"""Responsive Tk layout helpers for the PVZ Hybrid editor."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+DEFAULT_WINDOW_WIDTH = 900
+DEFAULT_WINDOW_HEIGHT = 720
+MIN_WINDOW_WIDTH = 600
+MIN_WINDOW_HEIGHT = 520
+SCREEN_MARGIN = 40
+
+
+class TkEvent(Protocol):
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class WindowGeometry:
+    width: int
+    height: int
+    x: int
+    y: int
+
+    def as_tk_geometry(self) -> str:
+        return f"{self.width}x{self.height}+{self.x}+{self.y}"
+
+    def as_tk_size(self) -> str:
+        return f"{self.width}x{self.height}"
+
+
+@dataclass(frozen=True)
+class ScrollableViewport:
+    container: Any
+    canvas: Any
+    frame: Any
+    vertical_scrollbar: Any
+    horizontal_scrollbar: Any
+    content_window_id: Any
+    sync_scroll_region: Callable[[TkEvent | None], None]
+    resize_content: Callable[[TkEvent], None]
+
+
+def initial_window_geometry(
+    *,
+    screen_width: int,
+    screen_height: int,
+    saved_x: int | None = None,
+    saved_y: int | None = None,
+    target_width: int = DEFAULT_WINDOW_WIDTH,
+    target_height: int = DEFAULT_WINDOW_HEIGHT,
+    min_width: int = MIN_WINDOW_WIDTH,
+    min_height: int = MIN_WINDOW_HEIGHT,
+    screen_margin: int = SCREEN_MARGIN,
+) -> WindowGeometry:
+    width = _clamp(target_width, min_width, max(min_width, screen_width - screen_margin))
+    height = _clamp(target_height, min_height, max(min_height, screen_height - screen_margin))
+    max_x = max(0, screen_width - width)
+    max_y = max(0, screen_height - height)
+    default_x = max_x // 2
+    default_y = max_y // 2
+
+    x = _clamp(saved_x if saved_x is not None else default_x, 0, max_x)
+    y = _clamp(saved_y if saved_y is not None else default_y, 0, max_y)
+    return WindowGeometry(width=width, height=height, x=x, y=y)
+
+
+def create_scrollable_viewport(
+    parent: Any,
+    *,
+    ttk_module: Any,
+    tk_module: Any,
+    min_content_width: int,
+    min_content_height: int,
+    bottom_margin: int,
+) -> ScrollableViewport:
+    container = ttk_module.Frame(parent)
+    container.pack(padx=5, pady=(5, bottom_margin), fill="both", expand=True)
+    container.grid_columnconfigure(0, weight=1)
+    container.grid_rowconfigure(0, weight=1)
+
+    canvas = tk_module.Canvas(container, highlightthickness=0)
+    vertical_scrollbar = ttk_module.Scrollbar(
+        container,
+        orient="vertical",
+        command=canvas.yview,
+    )
+    horizontal_scrollbar = ttk_module.Scrollbar(
+        container,
+        orient="horizontal",
+        command=canvas.xview,
+    )
+    frame = ttk_module.Frame(canvas)
+    content_window_id = canvas.create_window((0, 0), window=frame, anchor="nw")
+
+    def sync_scroll_region(event: TkEvent | None = None) -> None:
+        del event
+        canvas.configure(scrollregion=canvas.bbox("all"))
+
+    def resize_content(event: TkEvent) -> None:
+        canvas.itemconfigure(
+            content_window_id,
+            width=max(event.width, min_content_width),
+            height=max(event.height, min_content_height),
+        )
+
+    frame.bind("<Configure>", sync_scroll_region)
+    canvas.bind("<Configure>", resize_content)
+    canvas.configure(
+        yscrollcommand=vertical_scrollbar.set,
+        xscrollcommand=horizontal_scrollbar.set,
+    )
+
+    canvas.grid(row=0, column=0, sticky="nsew")
+    vertical_scrollbar.grid(row=0, column=1, sticky="ns")
+    horizontal_scrollbar.grid(row=1, column=0, sticky="ew")
+
+    return ScrollableViewport(
+        container=container,
+        canvas=canvas,
+        frame=frame,
+        vertical_scrollbar=vertical_scrollbar,
+        horizontal_scrollbar=horizontal_scrollbar,
+        content_window_id=content_window_id,
+        sync_scroll_region=sync_scroll_region,
+        resize_content=resize_content,
+    )
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return min(max(value, low), high)

--- a/responsive_tk.py
+++ b/responsive_tk.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 DEFAULT_WINDOW_WIDTH = 900
-DEFAULT_WINDOW_HEIGHT = 720
+DEFAULT_WINDOW_HEIGHT = 650
 MIN_WINDOW_WIDTH = 600
 MIN_WINDOW_HEIGHT = 520
 SCREEN_MARGIN = 40
@@ -61,7 +61,9 @@ def initial_window_geometry(
     max_x = max(0, screen_width - width)
     max_y = max(0, screen_height - height)
     default_x = max_x // 2
-    default_y = max_y // 2
+    default_y = (
+        0 if screen_height <= height + (screen_margin * 3) else max_y // 2
+    )
 
     x = _clamp(saved_x if saved_x is not None else default_x, 0, max_x)
     y = _clamp(saved_y if saved_y is not None else default_y, 0, max_y)

--- a/responsive_ui_smoke.py
+++ b/responsive_ui_smoke.py
@@ -1,0 +1,205 @@
+"""Render and capture a Windows Tk smoke screenshot for responsive layout checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+import responsive_tk
+
+SCREENSHOT_NAME = "responsive-ui-smoke.png"
+AUDIT_NAME = "responsive-ui-smoke.json"
+MIN_CONTENT_WIDTH = 900
+MIN_CONTENT_HEIGHT = 650
+MIN_SCREENSHOT_BYTES = 100
+
+
+class ImageLike(Protocol):
+    def getextrema(self) -> Sequence[tuple[int, int]]:
+        ...
+
+
+@dataclass(frozen=True)
+class SmokeAudit:
+    screenshot_name: str
+    screenshot_size_bytes: int
+    screenshot_varies: bool
+    window_width: int
+    window_height: int
+    canvas_width: int
+    canvas_height: int
+    min_content_width: int
+    min_content_height: int
+    scrollregion: list[int]
+    horizontal_scroll_available: bool
+    vertical_scroll_available: bool
+
+
+def build_audit(
+    *,
+    screenshot_path: Path,
+    screenshot_size_bytes: int,
+    screenshot_varies: bool,
+    window_width: int,
+    window_height: int,
+    canvas_width: int,
+    canvas_height: int,
+    scrollregion: tuple[int, int, int, int],
+) -> SmokeAudit:
+    scroll_width = scrollregion[2] - scrollregion[0]
+    scroll_height = scrollregion[3] - scrollregion[1]
+    return SmokeAudit(
+        screenshot_name=screenshot_path.name,
+        screenshot_size_bytes=screenshot_size_bytes,
+        screenshot_varies=screenshot_varies,
+        window_width=window_width,
+        window_height=window_height,
+        canvas_width=canvas_width,
+        canvas_height=canvas_height,
+        min_content_width=MIN_CONTENT_WIDTH,
+        min_content_height=MIN_CONTENT_HEIGHT,
+        scrollregion=list(scrollregion),
+        horizontal_scroll_available=scroll_width > canvas_width,
+        vertical_scroll_available=scroll_height > canvas_height,
+    )
+
+
+def write_audit(path: Path, audit: SmokeAudit) -> None:
+    path.write_text(
+        json.dumps(asdict(audit), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def assert_screenshot_evidence(path: Path, *, screenshot_varies: bool) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"responsive UI screenshot missing: {path}")
+    if path.stat().st_size < MIN_SCREENSHOT_BYTES:
+        raise ValueError(f"responsive UI screenshot too small: {path}")
+    if not screenshot_varies:
+        raise ValueError("responsive UI smoke captured a blank screenshot")
+
+
+def run_smoke(output_dir: Path) -> SmokeAudit:  # pragma: no cover - Windows GUI smoke
+    import tkinter as tk
+    from tkinter import ttk
+
+    from PIL import ImageGrab  # type: ignore[import-not-found]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    screenshot_path = output_dir / SCREENSHOT_NAME
+    audit_path = output_dir / AUDIT_NAME
+
+    root = tk.Tk()
+    try:
+        root.title("PVZ Hybrid responsive UI smoke")
+        geometry = responsive_tk.initial_window_geometry(
+            screen_width=root.winfo_screenwidth(),
+            screen_height=root.winfo_screenheight(),
+        )
+        root.geometry(geometry.as_tk_geometry())
+        root.minsize(responsive_tk.MIN_WINDOW_WIDTH, responsive_tk.MIN_WINDOW_HEIGHT)
+
+        viewport = responsive_tk.create_scrollable_viewport(
+            root,
+            ttk_module=ttk,
+            tk_module=tk,
+            min_content_width=MIN_CONTENT_WIDTH,
+            min_content_height=MIN_CONTENT_HEIGHT,
+            bottom_margin=25,
+        )
+        _populate_smoke_content(viewport.frame, ttk_module=ttk)
+
+        root.update_idletasks()
+        viewport.sync_scroll_region(None)
+        root.lift()
+        root.attributes("-topmost", True)
+        root.update()
+        time.sleep(0.5)
+        root.attributes("-topmost", False)
+        root.update()
+
+        left = root.winfo_rootx()
+        top = root.winfo_rooty()
+        right = left + root.winfo_width()
+        bottom = top + root.winfo_height()
+        image = ImageGrab.grab(bbox=(left, top, right, bottom)).convert("RGB")
+        screenshot_varies = _image_has_pixel_variation(image)
+        image.save(screenshot_path)
+
+        scrollregion = _parse_scrollregion(viewport.canvas.cget("scrollregion"))
+        audit = build_audit(
+            screenshot_path=screenshot_path,
+            screenshot_size_bytes=screenshot_path.stat().st_size,
+            screenshot_varies=screenshot_varies,
+            window_width=root.winfo_width(),
+            window_height=root.winfo_height(),
+            canvas_width=viewport.canvas.winfo_width(),
+            canvas_height=viewport.canvas.winfo_height(),
+            scrollregion=scrollregion,
+        )
+        assert_screenshot_evidence(screenshot_path, screenshot_varies=screenshot_varies)
+        write_audit(audit_path, audit)
+        return audit
+    finally:
+        root.destroy()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    run_smoke(args.output_dir)
+    return 0
+
+
+def _populate_smoke_content(parent: object, *, ttk_module: Any) -> None:  # pragma: no cover
+    notebook = ttk_module.Notebook(parent)
+    notebook.pack(fill="both", expand=True)
+
+    page = ttk_module.Frame(notebook, width=MIN_CONTENT_WIDTH, height=MIN_CONTENT_HEIGHT)
+    page.pack_propagate(False)
+    notebook.add(page, text="Common")
+
+    ttk_module.Label(page, text="Resource edits").place(x=8, y=8)
+    for index in range(12):
+        y = 36 + index * 32
+        ttk_module.Label(page, text=f"Shortcut {index + 1}").place(x=220, y=y)
+        ttk_module.Entry(page, width=16).place(x=320, y=y)
+        ttk_module.Button(page, text="Revise", width=8).place(x=470, y=y - 3)
+        ttk_module.Button(page, text=f"Action {index + 1}", width=14).place(x=735, y=y - 3)
+
+    ttk_module.Label(page, text="Quick planting").place(x=8, y=515)
+    for index in range(8):
+        x = 68 + index * 98
+        ttk_module.Combobox(page, width=7, values=("0", "1", "2")).place(x=x, y=542)
+
+    ttk_module.Label(page, text="Run in background").place(x=8, y=615)
+    ttk_module.Button(page, text="Load plugin").place(x=120, y=610)
+    ttk_module.Label(page, text="Language").place(x=700, y=615)
+    ttk_module.Combobox(page, width=10, values=("English", "中文")).place(x=770, y=610)
+
+
+def _image_has_pixel_variation(image: ImageLike) -> bool:  # pragma: no cover
+    extrema = image.getextrema()
+    return any(channel_min != channel_max for channel_min, channel_max in extrema)
+
+
+def _parse_scrollregion(value: object) -> tuple[int, int, int, int]:  # pragma: no cover
+    if isinstance(value, tuple):
+        if len(value) != 4:
+            raise ValueError(f"unexpected canvas scrollregion: {value}")
+        return cast(tuple[int, int, int, int], tuple(int(part) for part in value))
+    parts = str(value).split()
+    if len(parts) != 4:
+        raise ValueError(f"unexpected canvas scrollregion: {value}")
+    return cast(tuple[int, int, int, int], tuple(int(float(part)) for part in parts))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -59,6 +59,7 @@ def test_release_workflow_builds_windows_exe_artifact_and_checksum():
     assert "permissions:\n      contents: write" in workflow
     assert "actions/download-artifact@v8" in workflow
     assert "skip-decompress: true" not in workflow
+    assert "GH_REPO: ${{ github.repository }}" in workflow
     assert "gh release upload" in workflow
     assert (
         "github.ref_type == 'tag' && (startsWith(github.ref_name, 'v') || "

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -2,15 +2,87 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 
 
 def test_ci_workflow_runs_free_hosted_python_test_gate():
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
 
     assert "runs-on: ubuntu-latest" in workflow
-    assert "actions/checkout@v6" in workflow
+    assert "actions/checkout@v7" in workflow
     assert "actions/setup-python@v6" in workflow
     assert "cache: pip" in workflow
     assert "cache-dependency-path: requirements-dev.txt" in workflow
-    assert "python -m ruff check i18n.py i18n_audit.py tests" in workflow
-    assert "python -m pytest -q" in workflow
+    assert (
+        "python -m ruff check editor_config.py editor_ui_smoke.py i18n.py i18n_audit.py "
+        "editor_layout_audit.py editor_runtime.py release_package.py responsive_tk.py "
+        "responsive_ui_smoke.py tests"
+    ) in workflow
+    assert "python -m coverage run -m pytest -q" in workflow
+    assert "python -m coverage report" in workflow
+
+
+def test_release_workflow_builds_windows_exe_artifact_and_checksum():
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "push:\n  pull_request:" in workflow
+    assert "branches:" not in workflow
+    assert "tags:" not in workflow
+    assert "permissions:\n  contents: read" in workflow
+    assert "runs-on: windows-latest" in workflow
+    assert "actions/checkout@v7" in workflow
+    assert "https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe" in workflow
+    assert "python-3.8.10-win32" in workflow
+    assert "Include_pip=1" in workflow
+    assert "platform.architecture()[0] != \"32bit\"" in workflow
+    assert "sys.version_info[:2] != (3, 8)" in workflow
+    assert "& $python -m pip install -r requirements.txt" in workflow
+    assert "& $python -m pip install pyinstaller" in workflow
+    assert "pyinstaller" in workflow
+    assert "--onefile" in workflow
+    assert "--windowed" in workflow
+    assert "--icon res/icon/editor.ico" in workflow
+    assert "--add-data" in workflow
+    assert "locales:locales" in workflow
+    assert "res:res" in workflow
+    assert "win7_x86.PVZHybrid_Editor_b${{ steps.version.outputs.version }}" in workflow
+    assert "release_package.py" in workflow
+    assert "--github-output $env:GITHUB_OUTPUT" in workflow
+    assert "actions/upload-artifact@v7" in workflow
+    assert "archive: false" in workflow
+    assert "win7_x86.PVZHybrid_Editor_b${{ steps.version.outputs.version }}" in workflow
+    assert "release-assets:" in workflow
+    assert "needs: build-windows-exe" in workflow
+    assert "permissions:\n      contents: write" in workflow
+    assert "actions/download-artifact@v8" in workflow
+    assert workflow.count("skip-decompress: true") == 3
+    assert "gh release upload" in workflow
+    assert (
+        "github.ref_type == 'tag' && (startsWith(github.ref_name, 'v') || "
+        "startsWith(github.ref_name, 'b'))"
+    ) in workflow
+
+
+def test_release_workflow_captures_windows_responsive_ui_smoke_screenshot():
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "responsive-ui-smoke:" in workflow
+    assert "name: Windows responsive UI smoke" in workflow
+    assert "runs-on: windows-latest" in workflow
+    assert "actions/setup-python@v6" in workflow
+    assert "python responsive_ui_smoke.py --output-dir ui-smoke-artifacts" in workflow
+    assert "ui-smoke-artifacts/responsive-ui-smoke.png" in workflow
+    assert "ui-smoke-artifacts/responsive-ui-smoke.json" in workflow
+    assert workflow.count("archive: false") >= 5
+
+
+def test_release_workflow_captures_actual_editor_ui_smoke_screenshot():
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "actual-editor-ui-smoke:" in workflow
+    assert "name: Windows actual editor UI smoke" in workflow
+    assert "runs-on: windows-latest" in workflow
+    assert "python -m pip install -r requirements.txt" in workflow
+    assert "python editor_ui_smoke.py --output-dir editor-ui-smoke-artifacts" in workflow
+    assert "editor-ui-smoke-artifacts/editor-ui-smoke.png" in workflow
+    assert "editor-ui-smoke-artifacts/editor-ui-smoke.json" in workflow

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -22,15 +22,21 @@ def test_ci_workflow_runs_free_hosted_python_test_gate():
     assert "python -m coverage report" in workflow
 
 
-def test_release_workflow_builds_windows_exe_artifact_and_checksum():
+def test_release_workflow_builds_standard_and_win7_windows_test_artifacts():
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
+    assert "name: Build Windows Test EXE" in workflow
     assert "push:\n  pull_request:" in workflow
     assert "branches:" not in workflow
     assert "tags:" not in workflow
     assert "permissions:\n  contents: read" in workflow
+    assert "build-standard-windows-exe:" in workflow
+    assert "name: Windows standard executable" in workflow
+    assert "python-version: \"3.12\"" in workflow
+    assert "architecture: \"x64\"" in workflow
     assert "runs-on: windows-latest" in workflow
     assert "actions/checkout@v7" in workflow
+    assert "actions/setup-python@v6" in workflow
     assert "https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe" in workflow
     assert "python-3.8.10-win32" in workflow
     assert "Include_pip=1" in workflow
@@ -45,26 +51,24 @@ def test_release_workflow_builds_windows_exe_artifact_and_checksum():
     assert "--add-data" in workflow
     assert "locales:locales" in workflow
     assert "res:res" in workflow
-    assert "win7_x86.PVZHybrid_Editor_b${{ steps.version.outputs.version }}" in workflow
+    assert "git rev-parse HEAD" in workflow
+    assert "PVZHybrid_Editor_b${{ steps.build_version.outputs.version }}" in workflow
+    assert "win7_x86.PVZHybrid_Editor_b${{ steps.build_version.outputs.version }}" in workflow
     assert "release_package.py" in workflow
+    assert "--version \"${{ steps.build_version.outputs.version }}\"" in workflow
+    assert "--no-platform-tag" in workflow
+    assert "--platform-tag win7_x86" in workflow
     assert "--github-output $env:GITHUB_OUTPUT" in workflow
     assert "actions/upload-artifact@v7" in workflow
     assert "name: ${{ steps.package.outputs.exe_name }}" in workflow
     assert "name: ${{ steps.package.outputs.sha_name }}" in workflow
     assert "name: ${{ steps.package.outputs.manifest_name }}" in workflow
     assert "archive: false" not in workflow
-    assert "win7_x86.PVZHybrid_Editor_b${{ steps.version.outputs.version }}" in workflow
-    assert "release-assets:" in workflow
-    assert "needs: build-windows-exe" in workflow
-    assert "permissions:\n      contents: write" in workflow
-    assert "actions/download-artifact@v8" in workflow
-    assert "skip-decompress: true" not in workflow
-    assert "GH_REPO: ${{ github.repository }}" in workflow
-    assert "gh release upload" in workflow
-    assert (
-        "github.ref_type == 'tag' && (startsWith(github.ref_name, 'v') || "
-        "startsWith(github.ref_name, 'b'))"
-    ) in workflow
+    assert "release-assets:" not in workflow
+    assert "permissions:\n      contents: write" not in workflow
+    assert "actions/download-artifact@v8" not in workflow
+    assert "GH_REPO: ${{ github.repository }}" not in workflow
+    assert "gh release" not in workflow
 
 
 def test_release_workflow_captures_windows_responsive_ui_smoke_screenshot():

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -49,13 +49,16 @@ def test_release_workflow_builds_windows_exe_artifact_and_checksum():
     assert "release_package.py" in workflow
     assert "--github-output $env:GITHUB_OUTPUT" in workflow
     assert "actions/upload-artifact@v7" in workflow
-    assert "archive: false" in workflow
+    assert "name: ${{ steps.package.outputs.exe_name }}" in workflow
+    assert "name: ${{ steps.package.outputs.sha_name }}" in workflow
+    assert "name: ${{ steps.package.outputs.manifest_name }}" in workflow
+    assert "archive: false" not in workflow
     assert "win7_x86.PVZHybrid_Editor_b${{ steps.version.outputs.version }}" in workflow
     assert "release-assets:" in workflow
     assert "needs: build-windows-exe" in workflow
     assert "permissions:\n      contents: write" in workflow
     assert "actions/download-artifact@v8" in workflow
-    assert workflow.count("skip-decompress: true") == 3
+    assert "skip-decompress: true" not in workflow
     assert "gh release upload" in workflow
     assert (
         "github.ref_type == 'tag' && (startsWith(github.ref_name, 'v') || "
@@ -73,7 +76,6 @@ def test_release_workflow_captures_windows_responsive_ui_smoke_screenshot():
     assert "python responsive_ui_smoke.py --output-dir ui-smoke-artifacts" in workflow
     assert "ui-smoke-artifacts/responsive-ui-smoke.png" in workflow
     assert "ui-smoke-artifacts/responsive-ui-smoke.json" in workflow
-    assert workflow.count("archive: false") >= 5
 
 
 def test_release_workflow_captures_actual_editor_ui_smoke_screenshot():

--- a/tests/test_coverage_config.py
+++ b/tests/test_coverage_config.py
@@ -1,0 +1,36 @@
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+DEV_REQUIREMENTS = REPO_ROOT / "requirements-dev.txt"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_coverage_gate_requires_full_typed_core_coverage():
+    pyproject = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    requirements = DEV_REQUIREMENTS.read_text(encoding="utf-8")
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "coverage[toml]>=" in requirements
+
+    coverage_run = pyproject["tool"]["coverage"]["run"]
+    assert coverage_run["branch"] is True
+    assert coverage_run["source"] == [
+        "editor_config",
+        "editor_ui_smoke",
+        "i18n",
+        "i18n_audit",
+        "editor_layout_audit",
+        "editor_runtime",
+        "release_package",
+        "responsive_tk",
+        "responsive_ui_smoke",
+    ]
+
+    coverage_report = pyproject["tool"]["coverage"]["report"]
+    assert coverage_report["fail_under"] == 100
+    assert coverage_report["show_missing"] is True
+
+    assert "python -m coverage run -m pytest -q" in workflow
+    assert "python -m coverage report" in workflow

--- a/tests/test_editor_config.py
+++ b/tests/test_editor_config.py
@@ -1,0 +1,106 @@
+import json
+
+import pytest
+
+import editor_config
+import i18n
+
+
+def test_app_config_path_and_config_file_path_use_appdata_root(tmp_path):
+    app_path = editor_config.app_config_path(tmp_path)
+
+    assert app_path == tmp_path / "PVZHybrid_Editor"
+    assert editor_config.config_file_path(tmp_path) == app_path / "config.json"
+
+
+def test_app_config_path_rejects_missing_appdata_root():
+    with pytest.raises(RuntimeError, match="APPDATA"):
+        editor_config.app_config_path(None)
+
+
+def test_default_config_returns_independent_shortcut_copy():
+    first = editor_config.default_config()
+    second = editor_config.default_config()
+
+    first["shortcuts"]["key1"]["key"] = "changed"
+
+    assert second["language"] == i18n.DEFAULT_LANGUAGE
+    assert second["shortcuts"]["key1"] == {"key": "ctrl+space", "action": 0}
+    assert len(second["shortcuts"]) == 12
+
+
+def test_load_config_returns_default_for_missing_or_invalid_json(tmp_path):
+    config_path = tmp_path / "config.json"
+
+    assert editor_config.load_config(config_path)["language"] == i18n.DEFAULT_LANGUAGE
+
+    config_path.write_text("{not json", encoding="utf-8")
+
+    assert editor_config.load_config(config_path)["shortcuts"]["key12"]["action"] == 11
+
+    config_path.write_text("[]", encoding="utf-8")
+
+    assert editor_config.load_config(config_path)["language"] == i18n.DEFAULT_LANGUAGE
+
+
+def test_save_create_and_modify_config_round_trip(tmp_path):
+    config_path = tmp_path / "nested" / "config.json"
+
+    editor_config.create_config(config_path)
+    config = editor_config.load_config(config_path)
+
+    assert config["language"] == i18n.DEFAULT_LANGUAGE
+
+    editor_config.modify_config(config_path, "data", "sunadd", 25)
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["data"]["sunadd"] == 25
+
+    editor_config.modify_config(config_path, "data", "sunadd", 50)
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["data"]["sunadd"] == 50
+
+
+def test_language_config_helpers_normalize_and_persist_language(tmp_path):
+    config_path = tmp_path / "config.json"
+
+    editor_config.set_config_language(config_path, "en-us")
+
+    assert editor_config.get_config_language(config_path) == "en"
+
+    editor_config.save_config({"language": "missing"}, config_path)
+
+    assert editor_config.get_config_language(config_path) == i18n.DEFAULT_LANGUAGE
+
+
+def test_shortcut_helpers_update_existing_config_and_create_missing_section(tmp_path):
+    config_path = tmp_path / "config.json"
+
+    assert editor_config.get_shortcuts(config_path)["key1"]["key"] == "ctrl+space"
+
+    old_key = editor_config.set_shortcut(
+        config_path,
+        "key1",
+        key="Ctrl+Shift+A",
+        action=4,
+    )
+
+    assert old_key == "ctrl+space"
+    assert editor_config.get_shortcuts(config_path)["key1"] == {
+        "key": "Ctrl+Shift+A",
+        "action": 4,
+    }
+
+    editor_config.save_config({}, config_path)
+    old_key = editor_config.set_shortcut(
+        config_path,
+        "new",
+        key="Ctrl+Alt+N",
+        action=8,
+    )
+
+    assert old_key is None
+    assert editor_config.get_shortcuts(config_path)["new"] == {"key": "Ctrl+Alt+N", "action": 8}
+
+    editor_config.save_config({"shortcuts": []}, config_path)
+
+    assert editor_config.get_shortcuts(config_path) == {}

--- a/tests/test_editor_layout_audit.py
+++ b/tests/test_editor_layout_audit.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+import editor_layout_audit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EDITOR = REPO_ROOT / "editor.py"
+
+
+def test_main_window_uses_responsive_scrollable_viewport():
+    layout = editor_layout_audit.inspect_main_window_layout(EDITOR)
+
+    assert layout.imports_responsive_tk is True
+    assert layout.sets_minimum_window_size is True
+    assert layout.uses_initial_window_geometry is True
+    assert layout.uses_scrollable_viewport is True
+    assert layout.notebook_parent == "main_viewport.frame"
+    assert "600x650" not in layout.literal_geometries
+
+
+def test_layout_audit_reports_fixed_geometry_and_direct_notebook_parent(tmp_path):
+    editor = tmp_path / "editor.py"
+    editor.write_text(
+        "\n".join(
+            [
+                "def unrelated():",
+                "    main_window.geometry('300x300')",
+                "",
+                "def mainWindow():",
+                "    main_window.geometry('600x650')",
+                "    page_tab = ttk.Notebook(main_window)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    layout = editor_layout_audit.inspect_main_window_layout(editor)
+
+    assert layout.imports_responsive_tk is False
+    assert layout.sets_minimum_window_size is False
+    assert layout.uses_initial_window_geometry is False
+    assert layout.uses_scrollable_viewport is False
+    assert layout.notebook_parent == "main_window"
+    assert layout.literal_geometries == {"600x650"}
+
+
+def test_layout_audit_tolerates_dynamic_geometry_and_unparented_notebook(tmp_path):
+    editor = tmp_path / "editor.py"
+    editor.write_text(
+        "\n".join(
+            [
+                "def mainWindow():",
+                "    main_window.geometry(123)",
+                "    main_window.geometry()",
+                "    page_tab = ttk.Notebook()",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    layout = editor_layout_audit.inspect_main_window_layout(editor)
+
+    assert layout.notebook_parent is None
+    assert layout.literal_geometries == set()
+
+
+def test_game_detection_uses_runtime_helper_instead_of_repeated_version_chain():
+    detection = editor_layout_audit.inspect_game_detection(EDITOR)
+
+    assert detection.find_running_game_process_calls >= 2
+    assert detection.detect_game_version_calls == 1
+    assert detection.legacy_window_name_version_checks == set()
+    assert detection.legacy_win32_window_text_version_checks == set()
+
+
+def test_startup_game_search_failure_keeps_main_window_visible():
+    startup_search = editor_layout_audit.inspect_startup_game_search(EDITOR)
+
+    assert startup_search.calls_update_game_on_failure is False
+    assert startup_search.sets_not_found_status_on_failure is True
+
+
+def test_game_detection_audit_reports_legacy_literal_checks(tmp_path):
+    editor = tmp_path / "editor.py"
+    editor.write_text(
+        "\n".join(
+            [
+                "def chooseGame():",
+                "    if 'v2.0' in window_name:",
+                "        pass",
+                "    if 'v3.17' in win32gui.GetWindowText(hwnd):",
+                "        pass",
+                "    if 'v4.0' == window_name:",
+                "        pass",
+                "    if 'v5.0' in other_name in window_name:",
+                "        pass",
+                "    editor_runtime.detect_game_version(window_name)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    detection = editor_layout_audit.inspect_game_detection(editor)
+
+    assert detection.detect_game_version_calls == 1
+    assert detection.find_running_game_process_calls == 0
+    assert detection.legacy_window_name_version_checks == {"v2.0", "v5.0"}
+    assert detection.legacy_win32_window_text_version_checks == {"v3.17"}
+
+
+def test_startup_game_search_audit_reports_blocking_failure_path(tmp_path):
+    editor = tmp_path / "editor.py"
+    editor.write_text(
+        "\n".join(
+            [
+                "def mainWindow():",
+                "    def updateGame():",
+                "        pass",
+                "    def tryFindGame():",
+                "        try:",
+                "            pass",
+                "        except:",
+                "            updateGame()",
+                "            process_label['text'] = '其他状态'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    startup_search = editor_layout_audit.inspect_startup_game_search(editor)
+
+    assert startup_search.calls_update_game_on_failure is True
+    assert startup_search.sets_not_found_status_on_failure is False

--- a/tests/test_editor_layout_audit.py
+++ b/tests/test_editor_layout_audit.py
@@ -17,6 +17,26 @@ def test_main_window_uses_responsive_scrollable_viewport():
     assert "600x650" not in layout.literal_geometries
 
 
+def test_main_window_uses_bottom_bar_instead_of_overlaying_bottom_controls():
+    layout = editor_layout_audit.inspect_main_window_layout(EDITOR)
+
+    assert layout.uses_bottom_bar is True
+    assert layout.bottom_control_parents == {
+        "process_frame": "bottom_bar",
+        "back_ground_check": "bottom_bar",
+        "plugin_button": "bottom_bar",
+        "unsupported_label": "bottom_bar",
+        "language_frame": "bottom_bar",
+    }
+    assert layout.bottom_control_geometry_managers == {
+        "process_frame": ["pack"],
+        "back_ground_check": ["pack"],
+        "plugin_button": ["pack"],
+        "unsupported_label": ["pack"],
+        "language_frame": ["pack"],
+    }
+
+
 def test_layout_audit_reports_fixed_geometry_and_direct_notebook_parent(tmp_path):
     editor = tmp_path / "editor.py"
     editor.write_text(
@@ -28,6 +48,8 @@ def test_layout_audit_reports_fixed_geometry_and_direct_notebook_parent(tmp_path
                 "def mainWindow():",
                 "    main_window.geometry('600x650')",
                 "    page_tab = ttk.Notebook(main_window)",
+                "    process_frame = ttk.Frame(main_window)",
+                "    process_frame.place(x=0, y=0)",
             ]
         ),
         encoding="utf-8",
@@ -39,7 +61,10 @@ def test_layout_audit_reports_fixed_geometry_and_direct_notebook_parent(tmp_path
     assert layout.sets_minimum_window_size is False
     assert layout.uses_initial_window_geometry is False
     assert layout.uses_scrollable_viewport is False
+    assert layout.uses_bottom_bar is False
     assert layout.notebook_parent == "main_window"
+    assert layout.bottom_control_parents == {"process_frame": "main_window"}
+    assert layout.bottom_control_geometry_managers == {"process_frame": ["place"]}
     assert layout.literal_geometries == {"600x650"}
 
 
@@ -49,6 +74,7 @@ def test_layout_audit_tolerates_dynamic_geometry_and_unparented_notebook(tmp_pat
         "\n".join(
             [
                 "def mainWindow():",
+                "    (lambda: None)()",
                 "    main_window.geometry(123)",
                 "    main_window.geometry()",
                 "    page_tab = ttk.Notebook()",

--- a/tests/test_editor_runtime.py
+++ b/tests/test_editor_runtime.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+
+import editor_runtime
+
+
+def test_resource_path_uses_explicit_base_directory(tmp_path):
+    assert editor_runtime.resource_path(
+        "res/icon/editor.png",
+        base_dir=tmp_path,
+    ) == str(tmp_path / "res/icon/editor.png")
+
+
+def test_resource_path_uses_pyinstaller_meipass_when_available(tmp_path):
+    class FrozenRuntime:
+        _MEIPASS = str(tmp_path / "bundle")
+
+    assert editor_runtime.resource_path(
+        Path("locales/en.json"),
+        runtime=FrozenRuntime,
+    ) == str(tmp_path / "bundle" / "locales/en.json")
+
+
+def test_resource_path_falls_back_to_cwd_without_meipass(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    assert editor_runtime.resource_path("version.txt") == str(tmp_path / "version.txt")
+
+
+def test_main_window_title_formats_editor_and_game_versions():
+    assert (
+        editor_runtime.main_window_title("2.73", "3.17")
+        == "杂交版多功能修改器  2.73      游戏版本：3.17"
+    )
+    assert (
+        editor_runtime.main_window_title("2.73", None)
+        == "杂交版多功能修改器  2.73      游戏版本：Game not found"
+    )
+
+
+def test_detect_game_version_matches_longest_known_window_version_first():
+    assert editor_runtime.detect_game_version("PVZ Hybrid {{v3.17}}") == 3.17
+    assert editor_runtime.detect_game_version("PVZ Hybrid {{v3.13.2}}") == 3.132
+    assert editor_runtime.detect_game_version("PVZ Hybrid {{v3.1.5}}") == 3.15
+    assert editor_runtime.detect_game_version("PVZ Hybrid {{v3.15}}") == 3.151
+    assert editor_runtime.detect_game_version("PVZ Hybrid {{v2.3.7}}") == 2.37
+    assert editor_runtime.detect_game_version("PVZ Hybrid {{v2.3}}") == 2.3
+
+
+def test_detect_game_version_returns_none_for_unknown_title():
+    assert editor_runtime.detect_game_version("PlantsVsZombies.exe") is None
+
+
+def test_find_running_game_process_returns_memory_and_detected_version():
+    memory = object()
+    calls = []
+
+    def find_window(class_name, window_name):
+        calls.append(("find_window", class_name, window_name))
+        return 100
+
+    def get_window_thread_process_id(hwnd):
+        calls.append(("get_pid", hwnd))
+        return (0, 1234)
+
+    def get_window_text(hwnd):
+        calls.append(("get_title", hwnd))
+        return "PVZ Hybrid {{v3.17}}"
+
+    def create_memory(process_id):
+        calls.append(("memory", process_id))
+        return memory
+
+    def get_process_name(process_id):
+        calls.append(("process_name", process_id))
+        return "PVZHybrid.exe"
+
+    process = editor_runtime.find_running_game_process(
+        find_window=find_window,
+        get_window_thread_process_id=get_window_thread_process_id,
+        get_window_text=get_window_text,
+        create_memory=create_memory,
+        get_process_name=get_process_name,
+    )
+
+    assert process.process_id == 1234
+    assert process.window_title == "PVZ Hybrid {{v3.17}}"
+    assert process.detected_version == 3.17
+    assert process.memory is memory
+    assert process.process_name == "PVZHybrid.exe"
+    assert calls == [
+        ("find_window", "MainWindow", None),
+        ("get_pid", 100),
+        ("get_title", 100),
+        ("memory", 1234),
+        ("process_name", 1234),
+    ]
+
+
+def test_find_running_game_process_allows_unknown_game_version():
+    process = editor_runtime.find_running_game_process(
+        find_window=lambda class_name, window_name: 100,
+        get_window_thread_process_id=lambda hwnd: (0, 4321),
+        get_window_text=lambda hwnd: "PlantsVsZombies.exe",
+        create_memory=lambda process_id: object(),
+        get_process_name=lambda process_id: "PlantsVsZombies.exe",
+    )
+
+    assert process.process_id == 4321
+    assert process.detected_version is None
+
+
+def test_find_running_game_process_rejects_missing_window():
+    try:
+        editor_runtime.find_running_game_process(
+            find_window=lambda class_name, window_name: 0,
+            get_window_thread_process_id=lambda hwnd: (0, 0),
+            get_window_text=lambda hwnd: "",
+            create_memory=lambda process_id: object(),
+            get_process_name=lambda process_id: "",
+        )
+    except editor_runtime.GameProcessNotFound as exc:
+        assert str(exc) == "PVZ Hybrid game window not found"
+    else:
+        raise AssertionError("expected missing window to raise")
+
+
+def test_evaluate_update_response_strips_response_and_detects_update():
+    decision = editor_runtime.evaluate_update_response(
+        current_version="2.73",
+        response_text=" 2.74\n",
+    )
+
+    assert decision.latest_version == "2.74"
+    assert decision.is_blocked is False
+    assert decision.should_open_update_window is True
+
+
+def test_evaluate_update_response_detects_blocked_version_response():
+    decision = editor_runtime.evaluate_update_response(
+        current_version="2.73",
+        response_text="The content may contain violation information",
+    )
+
+    assert decision.latest_version == "The content may contain violation information"
+    assert decision.is_blocked is True
+    assert decision.should_open_update_window is False
+
+
+def test_evaluate_update_response_preserves_legacy_074_update_signal():
+    decision = editor_runtime.evaluate_update_response(
+        current_version="2.73",
+        response_text="0.74",
+    )
+
+    assert decision.should_open_update_window is True
+
+
+def test_should_open_update_window_compares_numeric_release_segments():
+    assert editor_runtime.should_open_update_window("2.9", "2.10") is True
+    assert editor_runtime.should_open_update_window("2.9", "2.9.1") is True
+    assert editor_runtime.should_open_update_window("2.9.0", "2.9") is False
+    assert editor_runtime.should_open_update_window("2.10", "2.9") is False
+
+
+def test_should_open_update_window_falls_back_to_existing_string_compare_for_unknown_versions():
+    assert editor_runtime.should_open_update_window("beta1", "beta2") is True
+    assert editor_runtime.should_open_update_window("beta2", "beta1") is False

--- a/tests/test_editor_ui_smoke.py
+++ b/tests/test_editor_ui_smoke.py
@@ -1,0 +1,282 @@
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+import editor_ui_smoke
+
+
+def test_build_editor_audit_records_actual_window_evidence():
+    audit = editor_ui_smoke.build_editor_audit(
+        screenshot_path=Path("editor-ui-smoke.png"),
+        screenshot_size_bytes=4096,
+        screenshot_varies=True,
+        window_width=900,
+        window_height=720,
+        notebook_width=873,
+        notebook_height=640,
+        title="PVZ Hybrid",
+        scrollbar_count=2,
+    )
+
+    assert audit.screenshot_name == "editor-ui-smoke.png"
+    assert audit.screenshot_size_bytes == 4096
+    assert audit.screenshot_varies is True
+    assert audit.window_width == 900
+    assert audit.window_height == 720
+    assert audit.notebook_width == 873
+    assert audit.notebook_height == 640
+    assert audit.title == "PVZ Hybrid"
+    assert audit.scrollbar_count == 2
+    assert audit.scrollbars_available is True
+
+
+def test_write_editor_audit_json_uses_stable_keys(tmp_path):
+    audit = editor_ui_smoke.EditorSmokeAudit(
+        screenshot_name="editor-ui-smoke.png",
+        screenshot_size_bytes=4096,
+        screenshot_varies=True,
+        window_width=900,
+        window_height=720,
+        notebook_width=873,
+        notebook_height=640,
+        title="PVZ Hybrid",
+        scrollbar_count=2,
+        scrollbars_available=True,
+    )
+    output = tmp_path / "audit.json"
+
+    editor_ui_smoke.write_audit(output, audit)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == {
+        "screenshot_name": "editor-ui-smoke.png",
+        "screenshot_size_bytes": 4096,
+        "screenshot_varies": True,
+        "window_width": 900,
+        "window_height": 720,
+        "notebook_width": 873,
+        "notebook_height": 640,
+        "title": "PVZ Hybrid",
+        "scrollbar_count": 2,
+        "scrollbars_available": True,
+    }
+
+
+def test_assert_editor_screenshot_evidence_rejects_bad_captures(tmp_path):
+    screenshot = tmp_path / "editor-ui-smoke.png"
+
+    with pytest.raises(FileNotFoundError):
+        editor_ui_smoke.assert_editor_screenshot_evidence(screenshot, screenshot_varies=True)
+
+    screenshot.write_bytes(b"x")
+    with pytest.raises(ValueError, match="too small"):
+        editor_ui_smoke.assert_editor_screenshot_evidence(screenshot, screenshot_varies=True)
+
+    screenshot.write_bytes(b"x" * 200)
+    with pytest.raises(ValueError, match="blank screenshot"):
+        editor_ui_smoke.assert_editor_screenshot_evidence(screenshot, screenshot_varies=False)
+
+    editor_ui_smoke.assert_editor_screenshot_evidence(screenshot, screenshot_varies=True)
+
+
+def test_find_first_widget_by_class_searches_descendants():
+    notebook = FakeWidget("TNotebook")
+    root = FakeWidget("Tk", children=[FakeWidget("Frame"), FakeWidget("Frame", [notebook])])
+
+    assert editor_ui_smoke.find_first_widget_by_class(root, "TNotebook") is notebook
+    assert editor_ui_smoke.find_first_widget_by_class(root, "Canvas") is None
+
+
+def test_count_widgets_by_class_searches_descendants():
+    root = FakeWidget(
+        "Tk",
+        children=[
+            FakeWidget("TScrollbar"),
+            FakeWidget("Frame", [FakeWidget("TScrollbar"), FakeWidget("TNotebook")]),
+        ],
+    )
+
+    assert editor_ui_smoke.count_widgets_by_class(root, "TScrollbar") == 2
+    assert editor_ui_smoke.count_widgets_by_class(root, "TNotebook") == 1
+
+
+def test_main_runs_editor_smoke_with_output_dir(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run_editor_smoke(output_dir):
+        captured["output_dir"] = output_dir
+        return editor_ui_smoke.EditorSmokeAudit(
+            screenshot_name="editor-ui-smoke.png",
+            screenshot_size_bytes=4096,
+            screenshot_varies=True,
+            window_width=900,
+            window_height=720,
+            notebook_width=873,
+            notebook_height=640,
+            title="PVZ Hybrid",
+            scrollbar_count=2,
+            scrollbars_available=True,
+        )
+
+    monkeypatch.setattr(editor_ui_smoke, "run_editor_smoke", fake_run_editor_smoke)
+
+    assert editor_ui_smoke.main(["--output-dir", str(tmp_path)]) == 0
+    assert captured == {"output_dir": tmp_path}
+
+
+def test_main_requires_output_dir():
+    with pytest.raises(SystemExit):
+        editor_ui_smoke.main([])
+
+
+def test_run_editor_smoke_wraps_window_factory(monkeypatch, tmp_path):
+    window = FakeEditorWindow()
+    updated_versions = []
+    updated_memories = []
+
+    def original_factory():
+        return window
+
+    pvz_data = SimpleNamespace(PVZ_version="2.73")
+
+    def update_pvz_version(version):
+        updated_versions.append(version)
+        pvz_data.PVZ_version = version
+
+    pvz_data.update_PVZ_version = update_pvz_version
+
+    def update_pvz_memory(memory):
+        updated_memories.append(memory)
+        pvz_data.PVZ_memory = memory
+
+    pvz_data.update_PVZ_memory = update_pvz_memory
+    editor_module = SimpleNamespace(
+        current_version="0.73",
+        PVZ_data=pvz_data,
+        requests=SimpleNamespace(),
+        Messagebox=SimpleNamespace(),
+        keyboard=SimpleNamespace(),
+        pvz=SimpleNamespace(),
+        ttk=SimpleNamespace(Window=original_factory),
+        win32gui=SimpleNamespace(),
+        win32process=SimpleNamespace(),
+        psutil=SimpleNamespace(),
+    )
+
+    def main_window():
+        hwnd = editor_module.win32gui.FindWindow("MainWindow", None)
+        _, process_id = editor_module.win32process.GetWindowThreadProcessId(hwnd)
+        editor_module.PVZ_data.update_PVZ_memory(editor_module.Pymem(process_id))
+
+        assert isinstance(editor_module.PVZ_data.PVZ_version, (int, float))
+        assert editor_module.PVZ_data.PVZ_memory.read_uint(0x41C965) == 304
+        assert editor_module.PVZ_data.PVZ_memory.process_id == 1234
+        created_window = editor_module.ttk.Window()
+        created_window.title("PVZ Hybrid")
+        created_window.mainloop()
+
+    editor_module.mainWindow = main_window
+
+    pil_module = ModuleType("PIL")
+    pil_module.ImageGrab = SimpleNamespace(grab=lambda bbox: FakeImage(bbox))
+    monkeypatch.setitem(sys.modules, "PIL", pil_module)
+    monkeypatch.setattr(editor_ui_smoke.importlib, "import_module", lambda name: editor_module)
+    monkeypatch.setattr(
+        editor_ui_smoke.responsive_ui_smoke,
+        "_image_has_pixel_variation",
+        lambda image: True,
+    )
+
+    audit = editor_ui_smoke.run_editor_smoke(tmp_path)
+
+    assert audit.screenshot_name == "editor-ui-smoke.png"
+    assert audit.screenshot_size_bytes == 200
+    assert audit.scrollbar_count == 2
+    assert audit.scrollbars_available is True
+    assert window.after_delays == [1500]
+    assert window.mainloop_called is True
+    assert window.destroyed is True
+    assert updated_versions == [3.17]
+    assert len(updated_memories) == 2
+    assert editor_module.ttk.Window is original_factory
+
+
+class FakeWidget:
+    def __init__(self, widget_class, children=None, width=40, height=20):
+        self._widget_class = widget_class
+        self._children = children or []
+        self._width = width
+        self._height = height
+
+    def winfo_class(self):
+        return self._widget_class
+
+    def winfo_children(self):
+        return self._children
+
+    def winfo_width(self):
+        return self._width
+
+    def winfo_height(self):
+        return self._height
+
+
+class FakeEditorWindow(FakeWidget):
+    def __init__(self):
+        super().__init__(
+            "Tk",
+            children=[
+                FakeWidget("TNotebook", width=873, height=640),
+                FakeWidget("TScrollbar"),
+                FakeWidget("TScrollbar"),
+            ],
+            width=900,
+            height=720,
+        )
+        self.after_delays = []
+        self.after_callbacks = []
+        self.mainloop_called = False
+        self.destroyed = False
+        self._title = ""
+
+    def after(self, delay, callback):
+        self.after_delays.append(delay)
+        self.after_callbacks.append(callback)
+
+    def mainloop(self, *args, **kwargs):
+        self.mainloop_called = True
+        for callback in self.after_callbacks:
+            callback()
+
+    def update_idletasks(self):
+        pass
+
+    def update(self):
+        pass
+
+    def winfo_rootx(self):
+        return 10
+
+    def winfo_rooty(self):
+        return 20
+
+    def title(self, value=None):
+        if value is not None:
+            self._title = value
+        return self._title
+
+    def destroy(self):
+        self.destroyed = True
+
+
+class FakeImage:
+    def __init__(self, bbox):
+        self.bbox = bbox
+
+    def convert(self, mode):
+        return self
+
+    def save(self, path):
+        Path(path).write_bytes(b"x" * 200)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -46,6 +46,23 @@ def test_translate_known_ui_text(language, expected):
     assert i18n.translate("选择游戏", language=language) == expected
 
 
+def test_language_helpers_normalize_aliases_and_fallbacks():
+    i18n.set_language("en-us")
+
+    assert i18n.get_language() == "en"
+    assert "English" in i18n.language_options()
+    assert i18n.language_code_for_native_name("English") == "en"
+    assert i18n.normalize_language(None) == i18n.DEFAULT_LANGUAGE
+    assert i18n.safe_language("missing") == i18n.DEFAULT_LANGUAGE
+
+    with pytest.raises(ValueError):
+        i18n.language_code_for_native_name("Missing")
+    with pytest.raises(ValueError):
+        i18n.normalize_language("missing")
+
+    i18n.set_language(i18n.DEFAULT_LANGUAGE)
+
+
 def test_translate_interpolates_named_values_and_falls_back_to_source_text():
     assert (
         i18n.translate(
@@ -57,6 +74,10 @@ def test_translate_interpolates_named_values_and_falls_back_to_source_text():
         == "PVZ Hybrid Multi-tool Editor  2.73      Game version: 3.17"
     )
     assert i18n.translate("未收录文案", language="en") == "未收录文案"
+    assert (
+        i18n.translate("app.title", language="en", version="2.73")
+        == "PVZ Hybrid Multi-tool Editor  {version}      Game version: {game_version}"
+    )
 
 
 def test_unsupported_language_is_rejected():
@@ -86,11 +107,89 @@ def test_registered_widgets_refresh_when_language_changes():
     assert widget.options["text"] == "Choose game"
 
 
+def test_register_widget_ignores_empty_metadata():
+    widget = FakeWidget()
+
+    i18n.register_widget(widget)
+    widget.configure(text="manual")
+    i18n.refresh_widgets()
+
+    assert widget.options["text"] == "manual"
+
+
 def test_translate_values_preserves_unknown_items():
     assert i18n.translate_values(["选择游戏", "Ctrl+F2"], language="en") == [
         "Choose game",
         "Ctrl+F2",
     ]
+
+
+def test_invalid_locale_payloads_are_rejected(tmp_path, monkeypatch):
+    locale_dir = tmp_path / "locales"
+    locale_dir.mkdir()
+
+    (locale_dir / "zh_CN.json").write_text(
+        json.dumps(
+            {
+                "code": "en",
+                "language_name": "Broken",
+                "native_name": "Broken",
+                "translations": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(i18n, "LOCALES_DIR", locale_dir)
+    monkeypatch.setattr(i18n, "_language_cache", None)
+
+    with pytest.raises(ValueError, match="Locale code mismatch"):
+        i18n.supported_languages()
+
+
+def test_invalid_catalog_translations_are_rejected(tmp_path, monkeypatch):
+    locale_dir = tmp_path / "locales"
+    locale_dir.mkdir()
+
+    (locale_dir / "zh_CN.json").write_text(
+        json.dumps(
+            {
+                "code": "zh_CN",
+                "language_name": "Chinese",
+                "native_name": "简体中文",
+                "translations": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(i18n, "LOCALES_DIR", locale_dir)
+    monkeypatch.setattr(i18n, "_catalog_cache", {})
+
+    with pytest.raises(ValueError, match="Invalid translations"):
+        i18n.translate("选择游戏", language="zh_CN")
+
+
+def test_segment_translation_skips_identity_and_format_keys(tmp_path, monkeypatch):
+    locale_dir = tmp_path / "locales"
+    locale_dir.mkdir()
+    (locale_dir / "zh_CN.json").write_text(
+        json.dumps(
+            {
+                "code": "zh_CN",
+                "language_name": "Chinese",
+                "native_name": "简体中文",
+                "translations": {
+                    "阳光": "Sun",
+                    "same": "same",
+                    "Ctrl+{key}": "Ctrl+{key}",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(i18n, "LOCALES_DIR", locale_dir)
+    monkeypatch.setattr(i18n, "_catalog_cache", {})
+
+    assert i18n.translate("阳光 same Ctrl+{key}", language="zh_CN") == "Sun same Ctrl+{key}"
 
 
 def test_install_tk_i18n_translates_widgets_and_notebook_tabs():
@@ -132,6 +231,247 @@ def test_install_tk_i18n_translates_widgets_and_notebook_tabs():
 
     assert label.options["text"] == "Elegir juego"
     assert notebook.tabs["common"]["text"] == "Herramientas comunes"
+
+
+def test_install_tk_i18n_patches_combobox_window_and_missing_classes():
+    class FakeLabel:
+        def __init__(self, *args, **kwargs):
+            del args
+            self.options = dict(kwargs)
+
+        def configure(self, **kwargs):
+            self.options.update(kwargs)
+
+    class FakeCombobox:
+        def __init__(self, *args, **kwargs):
+            del args
+            self.options = dict(kwargs)
+            self.selected = ""
+
+        def configure(self, **kwargs):
+            self.options.update(kwargs)
+
+        def get(self):
+            return self.selected
+
+        def set(self, value):
+            self.selected = value
+
+    class FakeNotebook:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+            self.tabs = {}
+
+        def add(self, child, **kwargs):
+            self.tabs[child] = kwargs
+            return child
+
+        def tab(self, child, **kwargs):
+            self.tabs[child].update(kwargs)
+
+    class FakeWindow:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+            self.current_title = "initial"
+
+        def title(self, text=None):
+            if text is None:
+                return self.current_title
+            self.current_title = text
+            return "title-result"
+
+    class FakeTtk:
+        Label = FakeLabel
+        Combobox = FakeCombobox
+        Notebook = FakeNotebook
+        Window = FakeWindow
+
+    i18n.set_language("en")
+    i18n.install_tk_i18n(FakeTtk)
+    i18n.install_tk_i18n(FakeTtk)
+
+    label = FakeTtk.Label(text=123)
+    assert label.options["text"] == 123
+
+    combobox = FakeTtk.Combobox(values=[1, "选择游戏"])
+    assert combobox.options["values"] == [1, "Choose game"]
+    combobox.set(1)
+    assert combobox.get() == 1
+    combobox.selected = "选择游戏"
+    assert combobox.get() == "选择游戏"
+    combobox.selected = "Choose game"
+    assert combobox.get() == "选择游戏"
+    combobox.set("Ctrl+F2")
+    assert combobox.get() == "Ctrl+F2"
+
+    notebook = FakeTtk.Notebook()
+    assert notebook.add("plain") == "plain"
+    assert notebook.add("common", text="常用功能") == "common"
+    assert notebook.tabs["common"]["text"] == "Common tools"
+
+    window = FakeTtk.Window()
+    assert window.title() == "initial"
+    assert window.title("选择游戏") is None
+    assert window.current_title == "Choose game"
+    assert window.title(123) == "title-result"
+    assert window.current_title == 123
+
+    i18n.set_language("es")
+    i18n.refresh_widgets()
+
+    assert combobox.options["values"] == [1, "Elegir juego"]
+    assert notebook.tabs["common"]["text"] == "Herramientas comunes"
+    assert window.current_title == "Elegir juego"
+    i18n.set_language(i18n.DEFAULT_LANGUAGE)
+
+
+def test_install_tk_i18n_tolerates_already_patched_or_minimal_widgets():
+    class NoSelectionCombobox:
+        def __init__(self, *args, **kwargs):
+            del args
+            self.options = dict(kwargs)
+
+        def configure(self, **kwargs):
+            self.options.update(kwargs)
+
+    class AlreadyPatchedCombobox(NoSelectionCombobox):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._i18n_value_methods_patched = True
+
+        def get(self):
+            return ""
+
+        def set(self, value):
+            self.selected = value
+
+    class AlreadyPatchedNotebook:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+            self._i18n_notebook_patched = True
+
+        def add(self, child, **kwargs):
+            del kwargs
+            return child
+
+    class WindowWithoutTitle:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+    class MinimalModule:
+        Combobox = NoSelectionCombobox
+        Notebook = AlreadyPatchedNotebook
+        Window = WindowWithoutTitle
+
+    class AlreadyPatchedModule:
+        Combobox = AlreadyPatchedCombobox
+
+    i18n.set_language("en")
+    i18n.install_tk_i18n(MinimalModule)
+    i18n.install_tk_i18n(AlreadyPatchedModule)
+
+    combo = MinimalModule.Combobox(values=["选择游戏"])
+    assert combo.options["values"] == ["Choose game"]
+    assert MinimalModule.Notebook().add("tab", text="常用功能") == "tab"
+    assert isinstance(MinimalModule.Window(), WindowWithoutTitle)
+
+    already_patched = AlreadyPatchedModule.Combobox(values=["选择游戏"])
+    assert already_patched.options["values"] == ["Choose game"]
+    assert already_patched.get() == ""
+    i18n.set_language(i18n.DEFAULT_LANGUAGE)
+
+
+def test_refresh_widgets_drops_stale_widget_notebook_and_window_registrations():
+    class FailsAfterRegister:
+        def __init__(self):
+            self.fail = False
+            self.options = {}
+
+        def configure(self, **kwargs):
+            if self.fail:
+                raise RuntimeError("stale widget")
+            self.options.update(kwargs)
+
+    class FailingNotebook:
+        def __init__(self):
+            self.fail = False
+            self.tabs = {"tab": {}}
+
+        def tab(self, child, **kwargs):
+            if self.fail:
+                raise RuntimeError("stale notebook")
+            self.tabs[child].update(kwargs)
+
+    class FailingWindow:
+        def __init__(self):
+            self.fail = False
+            self.current_title = ""
+
+        def title(self, text=None):
+            if text is None:
+                return self.current_title
+            if self.fail:
+                raise RuntimeError("stale window")
+            self.current_title = text
+
+    widget = FailsAfterRegister()
+    notebook = FailingNotebook()
+    window = FailingWindow()
+    i18n.set_language("en")
+
+    i18n.register_widget(widget, text="选择游戏")
+    i18n.register_notebook_tab(notebook, "tab", "常用功能")
+    i18n.register_window_title(window, "选择游戏")
+
+    widget.fail = True
+    notebook.fail = True
+    window.fail = True
+
+    i18n.refresh_widgets()
+    i18n.refresh_widgets()
+
+    assert widget.options["text"] == "Choose game"
+    assert notebook.tabs["tab"]["text"] == "Common tools"
+    assert window.current_title == "Choose game"
+    i18n.set_language(i18n.DEFAULT_LANGUAGE)
+
+
+def test_value_refresh_tolerates_widgets_without_working_get_or_set():
+    class WidgetWithoutGet:
+        def __init__(self):
+            self.options = {}
+
+        def configure(self, **kwargs):
+            self.options.update(kwargs)
+
+    class WidgetWithBrokenGet(WidgetWithoutGet):
+        def get(self):
+            raise RuntimeError("broken get")
+
+    class WidgetWithoutSet(WidgetWithoutGet):
+        def get(self):
+            return "选择游戏"
+
+    class WidgetWithBrokenSet(WidgetWithoutSet):
+        def set(self, value):
+            del value
+            raise RuntimeError("broken set")
+
+    i18n.set_language("en")
+    widgets = [
+        WidgetWithoutGet(),
+        WidgetWithBrokenGet(),
+        WidgetWithoutSet(),
+        WidgetWithBrokenSet(),
+    ]
+
+    for widget in widgets:
+        i18n.register_widget(widget, values=["选择游戏"])
+    i18n.refresh_widgets()
+
+    for widget in widgets:
+        assert widget.options["values"] == ["Choose game"]
+    i18n.set_language(i18n.DEFAULT_LANGUAGE)
 
 
 def test_translated_combobox_values_keep_source_values_for_business_logic():

--- a/tests/test_i18n_coverage.py
+++ b/tests/test_i18n_coverage.py
@@ -20,3 +20,38 @@ def test_all_static_editor_ui_texts_are_in_every_locale_catalog():
     )
 
     assert missing_by_locale == {}
+
+
+def test_i18n_audit_reports_missing_locale_keys(tmp_path):
+    locale_dir = tmp_path / "locales"
+    locale_dir.mkdir()
+    (locale_dir / "en.json").write_text(
+        '{"translations": {"已翻译": "Translated"}}',
+        encoding="utf-8",
+    )
+
+    missing_by_locale = i18n_audit.missing_locale_keys(
+        locale_dir=locale_dir,
+        source_texts={"已翻译", "未翻译"},
+        language_codes=["en"],
+    )
+
+    assert missing_by_locale == {"en": ["未翻译"]}
+
+
+def test_i18n_audit_ignores_title_calls_without_text(tmp_path):
+    source = tmp_path / "sample.py"
+    source.write_text(
+        "\n".join(
+            [
+                "root.title()",
+                "root.title('标题')",
+                "label(text='文案')",
+                "combo(values=('选项', 'Ctrl+F2'))",
+                "button(text=dynamic_text)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert i18n_audit.extract_static_ui_texts(source) == {"标题", "文案", "选项"}

--- a/tests/test_release_package.py
+++ b/tests/test_release_package.py
@@ -1,0 +1,134 @@
+import hashlib
+from datetime import date
+
+import pytest
+
+import release_package
+
+
+def test_prepare_release_package_writes_manifest_checksum_and_github_outputs(tmp_path):
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    exe_name = "win7_x86.PVZHybrid_Editor_b0.73.exe"
+    exe_path = dist_dir / exe_name
+    payload = b"pvz hybrid editor"
+    exe_path.write_bytes(payload)
+    github_output = tmp_path / "github_output.txt"
+    github_output.write_text("existing=value\n", encoding="utf-8")
+
+    package = release_package.prepare_release_package(
+        dist_dir=dist_dir,
+        version="0.73",
+        built_at=date(2026, 5, 10),
+        github_output=github_output,
+    )
+
+    digest = hashlib.sha256(payload).hexdigest()
+    assert package.exe_name == exe_name
+    assert package.manifest_name == f"{exe_name}.txt"
+    assert package.sha_name == f"{exe_name}.sha256"
+    assert package.sha256 == digest
+    assert package.size_bytes == len(payload)
+    assert package.size_mb == 0.0
+    assert package.date_label == "May 10"
+
+    assert (dist_dir / f"{exe_name}.txt").read_text(encoding="utf-8").splitlines() == [
+        exe_name,
+        f"sha256:{digest}",
+        str(len(payload)),
+        "0.0 MB",
+        "May 10",
+    ]
+    assert (dist_dir / f"{exe_name}.sha256").read_text(encoding="ascii") == (
+        f"sha256:{digest}  {exe_name}\n"
+    )
+    assert github_output.read_text(encoding="utf-8").splitlines() == [
+        "existing=value",
+        f"exe_name={exe_name}",
+        f"manifest_name={exe_name}.txt",
+        f"sha_name={exe_name}.sha256",
+        f"exe_path={dist_dir / exe_name}",
+        f"manifest_path={dist_dir / f'{exe_name}.txt'}",
+        f"sha_path={dist_dir / f'{exe_name}.sha256'}",
+    ]
+
+
+def test_prepare_release_package_rejects_missing_executable(tmp_path):
+    with pytest.raises(FileNotFoundError, match="Expected executable missing"):
+        release_package.prepare_release_package(
+            dist_dir=tmp_path,
+            version="0.73",
+            built_at=date(2026, 5, 10),
+        )
+
+
+def test_prepare_release_package_can_skip_github_output(tmp_path):
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "win7_x86.PVZHybrid_Editor_b0.73.exe").write_bytes(b"abc")
+
+    package = release_package.prepare_release_package(
+        dist_dir=dist_dir,
+        version="0.73",
+        built_at=date(2026, 5, 10),
+    )
+
+    assert package.exe_path.exists()
+    assert package.manifest_path.exists()
+    assert package.sha_path.exists()
+
+
+def test_read_version_strips_whitespace_and_rejects_empty_file(tmp_path):
+    version_file = tmp_path / "version.txt"
+    version_file.write_text("  2.73\n", encoding="utf-8")
+    assert release_package.read_version(version_file) == "2.73"
+
+    version_file.write_text(" \n", encoding="utf-8")
+    with pytest.raises(ValueError, match="version.txt is empty"):
+        release_package.read_version(version_file)
+
+
+def test_cli_prepares_package_and_writes_github_output(tmp_path):
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    version_file = tmp_path / "version.txt"
+    version_file.write_text("0.73\n", encoding="utf-8")
+    (dist_dir / "win7_x86.PVZHybrid_Editor_b0.73.exe").write_bytes(b"abc")
+    github_output = tmp_path / "github_output.txt"
+
+    exit_code = release_package.main(
+        [
+            "--dist-dir",
+            str(dist_dir),
+            "--version-file",
+            str(version_file),
+            "--github-output",
+            str(github_output),
+            "--built-at",
+            "2026-05-10",
+        ]
+    )
+
+    assert exit_code == 0
+    assert "sha_path=" in github_output.read_text(encoding="utf-8")
+
+
+def test_cli_uses_current_date_when_built_at_is_omitted(tmp_path):
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    version_file = tmp_path / "version.txt"
+    version_file.write_text("0.73\n", encoding="utf-8")
+    exe_name = "win7_x86.PVZHybrid_Editor_b0.73.exe"
+    (dist_dir / exe_name).write_bytes(b"abc")
+
+    exit_code = release_package.main(
+        [
+            "--dist-dir",
+            str(dist_dir),
+            "--version-file",
+            str(version_file),
+        ]
+    )
+
+    assert exit_code == 0
+    assert (dist_dir / f"{exe_name}.txt").exists()

--- a/tests/test_release_package.py
+++ b/tests/test_release_package.py
@@ -78,6 +78,25 @@ def test_prepare_release_package_can_skip_github_output(tmp_path):
     assert package.sha_path.exists()
 
 
+def test_prepare_release_package_can_omit_platform_tag_for_standard_build(tmp_path):
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    commit = "0123456789abcdef0123456789abcdef01234567"
+    exe_name = f"PVZHybrid_Editor_b{commit}.exe"
+    (dist_dir / exe_name).write_bytes(b"abc")
+
+    package = release_package.prepare_release_package(
+        dist_dir=dist_dir,
+        version=commit,
+        built_at=date(2026, 5, 10),
+        platform_tag="",
+    )
+
+    assert package.exe_name == exe_name
+    assert package.manifest_path.name == f"{exe_name}.txt"
+    assert package.sha_path.name == f"{exe_name}.sha256"
+
+
 def test_read_version_strips_whitespace_and_rejects_empty_file(tmp_path):
     version_file = tmp_path / "version.txt"
     version_file.write_text("  2.73\n", encoding="utf-8")
@@ -111,6 +130,41 @@ def test_cli_prepares_package_and_writes_github_output(tmp_path):
 
     assert exit_code == 0
     assert "sha_path=" in github_output.read_text(encoding="utf-8")
+
+
+def test_cli_accepts_literal_commit_version_and_standard_build(tmp_path):
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    commit = "0123456789abcdef0123456789abcdef01234567"
+    exe_name = f"PVZHybrid_Editor_b{commit}.exe"
+    (dist_dir / exe_name).write_bytes(b"abc")
+
+    exit_code = release_package.main(
+        [
+            "--dist-dir",
+            str(dist_dir),
+            "--version",
+            commit,
+            "--no-platform-tag",
+            "--built-at",
+            "2026-05-10",
+        ]
+    )
+
+    assert exit_code == 0
+    assert (dist_dir / f"{exe_name}.txt").exists()
+
+
+def test_cli_rejects_empty_literal_version(tmp_path):
+    with pytest.raises(ValueError, match="version is empty"):
+        release_package.main(
+            [
+                "--dist-dir",
+                str(tmp_path),
+                "--version",
+                " ",
+            ]
+        )
 
 
 def test_cli_uses_current_date_when_built_at_is_omitted(tmp_path):

--- a/tests/test_responsive_tk.py
+++ b/tests/test_responsive_tk.py
@@ -10,10 +10,23 @@ def test_initial_window_geometry_centers_default_size_on_large_screen():
     )
 
     assert geometry.width == 900
-    assert geometry.height == 720
+    assert geometry.height == 650
     assert geometry.x == 510
-    assert geometry.y == 180
-    assert geometry.as_tk_geometry() == "900x720+510+180"
+    assert geometry.y == 215
+    assert geometry.as_tk_geometry() == "900x650+510+215"
+
+
+def test_initial_window_geometry_keeps_compact_windows_screen_above_taskbar_area():
+    geometry = responsive_tk.initial_window_geometry(
+        screen_width=1024,
+        screen_height=768,
+    )
+
+    assert geometry.width == 900
+    assert geometry.height == 650
+    assert geometry.x == 62
+    assert geometry.y == 0
+    assert geometry.as_tk_geometry() == "900x650+62+0"
 
 
 def test_initial_window_geometry_clamps_saved_position_to_visible_screen():

--- a/tests/test_responsive_tk.py
+++ b/tests/test_responsive_tk.py
@@ -1,0 +1,145 @@
+from dataclasses import dataclass
+
+import responsive_tk
+
+
+def test_initial_window_geometry_centers_default_size_on_large_screen():
+    geometry = responsive_tk.initial_window_geometry(
+        screen_width=1920,
+        screen_height=1080,
+    )
+
+    assert geometry.width == 900
+    assert geometry.height == 720
+    assert geometry.x == 510
+    assert geometry.y == 180
+    assert geometry.as_tk_geometry() == "900x720+510+180"
+
+
+def test_initial_window_geometry_clamps_saved_position_to_visible_screen():
+    geometry = responsive_tk.initial_window_geometry(
+        screen_width=700,
+        screen_height=640,
+        saved_x=900,
+        saved_y=-40,
+    )
+
+    assert geometry.width == 660
+    assert geometry.height == 600
+    assert geometry.x == 40
+    assert geometry.y == 0
+    assert geometry.as_tk_size() == "660x600"
+
+
+def test_scrollable_viewport_keeps_design_area_available_inside_small_window():
+    parent = FakeFrame()
+
+    viewport = responsive_tk.create_scrollable_viewport(
+        parent,
+        ttk_module=FakeTtk,
+        tk_module=FakeTk,
+        min_content_width=900,
+        min_content_height=650,
+        bottom_margin=25,
+    )
+
+    assert viewport.container.grid_columns[0]["weight"] == 1
+    assert viewport.container.grid_rows[0]["weight"] == 1
+    assert viewport.canvas.options["yscrollcommand"] == viewport.vertical_scrollbar.set
+    assert viewport.canvas.options["xscrollcommand"] == viewport.horizontal_scrollbar.set
+    assert viewport.vertical_scrollbar.options["command"] == viewport.canvas.yview
+    assert viewport.horizontal_scrollbar.options["command"] == viewport.canvas.xview
+
+    viewport.sync_scroll_region(None)
+    assert viewport.canvas.options["scrollregion"] == (0, 0, 900, 650)
+
+    viewport.resize_content(FakeEvent(width=600, height=500))
+
+    assert viewport.canvas.itemconfigure_calls[-1] == (
+        viewport.content_window_id,
+        {"width": 900, "height": 650},
+    )
+
+    viewport.resize_content(FakeEvent(width=1100, height=720))
+
+    assert viewport.canvas.itemconfigure_calls[-1] == (
+        viewport.content_window_id,
+        {"width": 1100, "height": 720},
+    )
+
+
+@dataclass
+class FakeEvent:
+    width: int
+    height: int
+
+
+class FakeWidget:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.options = dict(kwargs)
+        self.bindings = {}
+        self.grid_calls = []
+        self.pack_calls = []
+        self.grid_columns = {}
+        self.grid_rows = {}
+
+    def configure(self, **kwargs):
+        self.options.update(kwargs)
+
+    def bind(self, event, callback):
+        self.bindings[event] = callback
+
+    def grid(self, **kwargs):
+        self.grid_calls.append(kwargs)
+
+    def pack(self, **kwargs):
+        self.pack_calls.append(kwargs)
+
+    def grid_columnconfigure(self, index, **kwargs):
+        self.grid_columns[index] = kwargs
+
+    def grid_rowconfigure(self, index, **kwargs):
+        self.grid_rows[index] = kwargs
+
+
+class FakeFrame(FakeWidget):
+    pass
+
+
+class FakeScrollbar(FakeWidget):
+    def set(self, *args):
+        self.options["set_args"] = args
+
+
+class FakeCanvas(FakeWidget):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.itemconfigure_calls = []
+
+    def create_window(self, *args, **kwargs):
+        self.window_args = args
+        self.window_kwargs = kwargs
+        return "content-window"
+
+    def itemconfigure(self, item_id, **kwargs):
+        self.itemconfigure_calls.append((item_id, kwargs))
+
+    def bbox(self, item_id):
+        assert item_id == "all"
+        return (0, 0, 900, 650)
+
+    def yview(self, *args):
+        self.options["yview_args"] = args
+
+    def xview(self, *args):
+        self.options["xview_args"] = args
+
+
+class FakeTtk:
+    Frame = FakeFrame
+    Scrollbar = FakeScrollbar
+
+
+class FakeTk:
+    Canvas = FakeCanvas

--- a/tests/test_responsive_ui_smoke.py
+++ b/tests/test_responsive_ui_smoke.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import responsive_ui_smoke
+
+
+def test_build_audit_records_window_scroll_and_pixel_evidence():
+    audit = responsive_ui_smoke.build_audit(
+        screenshot_path=Path("responsive-ui-smoke.png"),
+        screenshot_size_bytes=2048,
+        screenshot_varies=True,
+        window_width=900,
+        window_height=720,
+        canvas_width=850,
+        canvas_height=640,
+        scrollregion=(0, 0, 900, 650),
+    )
+
+    assert audit.screenshot_name == "responsive-ui-smoke.png"
+    assert audit.screenshot_size_bytes == 2048
+    assert audit.screenshot_varies is True
+    assert audit.window_width == 900
+    assert audit.window_height == 720
+    assert audit.min_content_width == 900
+    assert audit.min_content_height == 650
+    assert audit.horizontal_scroll_available is True
+    assert audit.vertical_scroll_available is True
+
+
+def test_write_audit_json_uses_stable_keys(tmp_path):
+    audit = responsive_ui_smoke.SmokeAudit(
+        screenshot_name="responsive-ui-smoke.png",
+        screenshot_size_bytes=2048,
+        screenshot_varies=True,
+        window_width=900,
+        window_height=720,
+        canvas_width=850,
+        canvas_height=640,
+        min_content_width=900,
+        min_content_height=650,
+        scrollregion=[0, 0, 900, 650],
+        horizontal_scroll_available=True,
+        vertical_scroll_available=True,
+    )
+    output = tmp_path / "audit.json"
+
+    responsive_ui_smoke.write_audit(output, audit)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == {
+        "screenshot_name": "responsive-ui-smoke.png",
+        "screenshot_size_bytes": 2048,
+        "screenshot_varies": True,
+        "window_width": 900,
+        "window_height": 720,
+        "canvas_width": 850,
+        "canvas_height": 640,
+        "min_content_width": 900,
+        "min_content_height": 650,
+        "scrollregion": [0, 0, 900, 650],
+        "horizontal_scroll_available": True,
+        "vertical_scroll_available": True,
+    }
+
+
+def test_assert_screenshot_evidence_rejects_blank_or_missing_file(tmp_path):
+    screenshot = tmp_path / "responsive-ui-smoke.png"
+
+    try:
+        responsive_ui_smoke.assert_screenshot_evidence(screenshot, screenshot_varies=True)
+    except FileNotFoundError as error:
+        assert "responsive-ui-smoke.png" in str(error)
+    else:
+        raise AssertionError("missing screenshot should fail")
+
+    screenshot.write_bytes(b"x" * 200)
+
+    try:
+        responsive_ui_smoke.assert_screenshot_evidence(screenshot, screenshot_varies=False)
+    except ValueError as error:
+        assert "blank screenshot" in str(error)
+    else:
+        raise AssertionError("blank screenshot should fail")
+
+    responsive_ui_smoke.assert_screenshot_evidence(screenshot, screenshot_varies=True)
+
+
+def test_assert_screenshot_evidence_rejects_too_small_file(tmp_path):
+    screenshot = tmp_path / "responsive-ui-smoke.png"
+    screenshot.write_bytes(b"x")
+
+    try:
+        responsive_ui_smoke.assert_screenshot_evidence(screenshot, screenshot_varies=True)
+    except ValueError as error:
+        assert "too small" in str(error)
+    else:
+        raise AssertionError("tiny screenshot should fail")
+
+
+def test_main_runs_smoke_with_output_dir(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run_smoke(output_dir):
+        captured["output_dir"] = output_dir
+        return responsive_ui_smoke.SmokeAudit(
+            screenshot_name="responsive-ui-smoke.png",
+            screenshot_size_bytes=2048,
+            screenshot_varies=True,
+            window_width=900,
+            window_height=720,
+            canvas_width=850,
+            canvas_height=640,
+            min_content_width=900,
+            min_content_height=650,
+            scrollregion=[0, 0, 900, 650],
+            horizontal_scroll_available=True,
+            vertical_scroll_available=True,
+        )
+
+    monkeypatch.setattr(responsive_ui_smoke, "run_smoke", fake_run_smoke)
+
+    assert responsive_ui_smoke.main(["--output-dir", str(tmp_path)]) == 0
+    assert captured == {"output_dir": tmp_path}
+
+
+def test_main_requires_output_dir():
+    with pytest.raises(SystemExit):
+        responsive_ui_smoke.main([])

--- a/tests/test_type_safety_config.py
+++ b/tests/test_type_safety_config.py
@@ -1,0 +1,34 @@
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+DEV_REQUIREMENTS = REPO_ROOT / "requirements-dev.txt"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_mypy_gate_covers_typed_core_modules():
+    pyproject = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    requirements = DEV_REQUIREMENTS.read_text(encoding="utf-8")
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "mypy>=" in requirements
+
+    mypy_config = pyproject["tool"]["mypy"]
+    assert mypy_config["python_version"] == "3.11"
+    assert mypy_config["files"] == [
+        "editor_config.py",
+        "editor_ui_smoke.py",
+        "i18n.py",
+        "i18n_audit.py",
+        "editor_layout_audit.py",
+        "editor_runtime.py",
+        "release_package.py",
+        "responsive_tk.py",
+        "responsive_ui_smoke.py",
+    ]
+    assert mypy_config["disallow_untyped_defs"] is True
+    assert mypy_config["check_untyped_defs"] is True
+    assert mypy_config["warn_return_any"] is True
+
+    assert "python -m mypy" in workflow

--- a/tests/test_type_safety_config.py
+++ b/tests/test_type_safety_config.py
@@ -30,5 +30,6 @@ def test_mypy_gate_covers_typed_core_modules():
     assert mypy_config["disallow_untyped_defs"] is True
     assert mypy_config["check_untyped_defs"] is True
     assert mypy_config["warn_return_any"] is True
+    assert mypy_config["strict"] is True
 
     assert "python -m mypy" in workflow


### PR DESCRIPTION
## Summary

- add typed CI/release pipeline with pytest, 100% coverage enforcement, ruff, strict mypy, and Windows x86 PyInstaller build
- publish downloadable Windows artifacts on every push/PR run: exe, sha256, and manifest text
- publish the same artifact set as GitHub Release assets on matching version tags
- repair i18n catalog/widget coverage from PR #30 and keep Tk i18n refresh behavior tested
- make the main editor viewport responsive/scrollable, move bottom controls into a packed footer bar, and keep compact Windows screens above taskbar overlap
- add static layout audits plus Windows responsive and real-editor UI smoke screenshots

## Verification

Latest PR head: 2f16facf31860957f4097e9ba353f3c938bf1d5b

Remote checks on EFrostBlade/PVZHybrid_Editor:

- CI: https://github.com/EFrostBlade/PVZHybrid_Editor/actions/runs/28842390125
  - Python 3.11: success
  - Python 3.12: success
- Build Windows EXE: https://github.com/EFrostBlade/PVZHybrid_Editor/actions/runs/28842390127
  - Windows x86 executable: success
  - Windows responsive UI smoke: success
  - Windows actual editor UI smoke: success

Local checks:

- rtk .venv/bin/python -m pytest -q -> 82 passed
- rtk .venv/bin/python -m coverage report -> TOTAL 100%, 866 statements, 258 branches
- rtk .venv/bin/python -m ruff check editor_config.py editor_ui_smoke.py i18n.py i18n_audit.py editor_layout_audit.py editor_runtime.py release_package.py responsive_tk.py responsive_ui_smoke.py tests -> passed
- rtk .venv/bin/python -m mypy -> passed with strict=true, 9 source files

## PR run artifacts verified from upstream run 28842390127

- win7_x86.PVZHybrid_Editor_b2.73.exe
  - size: 23,414,419 bytes / 22.3 MB
  - sha256: 4551ed458b718281eb3a07d7d02488b27578c0eef3c3628b016602c80b130fd0
  - manifest lines: exe name, sha256, byte size, MB size, date label
- responsive-ui-smoke.png
  - size: 23,669 bytes
  - audit: screenshot_varies=true, window=900x650, horizontal_scroll_available=true, vertical_scroll_available=true
- editor-ui-smoke.png
  - size: 100,350 bytes
  - audit: screenshot_varies=true, window=900x650, notebook=900x650, scrollbar_count=7
  - visual check from downloaded screenshot: bottom controls are visible; taskbar no longer covers the editor footer

## Tag release smoke verified on fork

- tag: b2.73-ci-smoke-2f16fac on sommio/PVZHybrid_Editor
- workflow: https://github.com/sommio/PVZHybrid_Editor/actions/runs/28842498230
- release: https://github.com/sommio/PVZHybrid_Editor/releases/tag/b2.73-ci-smoke-2f16fac
- Publish tag release assets job: success
- downloaded release assets and verified:
  - win7_x86.PVZHybrid_Editor_b2.73.exe
  - size: 23,415,170 bytes / 22.3 MB
  - sha256: ee39e8436a4a7046a04040fcebb164e1bbe6a97612daa3f575c9d4d7c8ae5b82
  - .sha256 file and manifest match the downloaded exe